### PR TITLE
시설을 대여할 수 있는 시간, 불가능한 시간을 구별할 수 있는 기능 구현

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
@@ -1,4 +1,4 @@
-package com.example.rentalSystem.domain.facility.presentation.controller;
+package com.example.rentalSystem.domain.facility.controller;
 
 import com.example.rentalSystem.domain.facility.dto.request.CreateFacilityRequestDto;
 import com.example.rentalSystem.domain.facility.dto.request.UpdateFacilityRequestDto;

--- a/src/main/java/com/example/rentalSystem/domain/facility/convert/TimeSlotConverter.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/convert/TimeSlotConverter.java
@@ -1,0 +1,35 @@
+package com.example.rentalSystem.domain.facility.convert;
+
+import com.example.rentalSystem.domain.facility.entity.TimeSlot;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Convert;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+@Convert
+public class TimeSlotConverter implements
+    AttributeConverter<TimeSlot, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(TimeSlot timeSlot) {
+        try {
+            return mapper.writeValueAsString(timeSlot);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public TimeSlot convertToEntityAttribute(String data) {
+        try {
+            return mapper.readValue(data, new TypeReference<TimeSlot>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException();
+        }
+    }
+
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/convert/TimeSlotConverter.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/convert/TimeSlotConverter.java
@@ -25,7 +25,7 @@ public class TimeSlotConverter implements
     @Override
     public TimeSlot convertToEntityAttribute(String data) {
         try {
-            return mapper.readValue(data, new TypeReference<TimeSlot>() {
+            return mapper.readValue(data, new TypeReference<>() {
             });
         } catch (JsonProcessingException e) {
             throw new RuntimeException();

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
@@ -1,8 +1,8 @@
 package com.example.rentalSystem.domain.facility.dto.request;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 
 public record CreateFacilityRequestDto(
     String name,
@@ -12,7 +12,8 @@ public record CreateFacilityRequestDto(
     String allowedBoundary,
     List<String> supportFacilities,
     String pic,
-    Map<String, List<String>> possibleTimes,
+    LocalTime startTime,
+    LocalTime endTime,
     boolean isAvailable
 ) {
 
@@ -25,7 +26,8 @@ public record CreateFacilityRequestDto(
             .allowedBoundary(allowedBoundary)
             .supportFacilities(supportFacilities)
             .pic(pic)
-            .possibleTimes(possibleTimes)
+            .startTime(startTime)
+            .endTime(endTime)
             .isAvailable(isAvailable)
             .build();
     }

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
@@ -1,9 +1,7 @@
 package com.example.rentalSystem.domain.facility.dto.response;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
-import com.example.rentalSystem.domain.facility.entity.TimeTable;
 import java.util.List;
-import java.util.Map;
 import lombok.Builder;
 
 @Builder

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
@@ -1,6 +1,7 @@
 package com.example.rentalSystem.domain.facility.dto.response;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.facility.entity.TimeTable;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
@@ -15,8 +16,7 @@ public record FacilityResponse(
     Long capacity,
     String allowedBoundary,
     List<String> supportFacilities,
-    String pic,
-    Map<String, List<String>> possibleTimes
+    String pic
 ) {
 
     public static FacilityResponse fromFacility(Facility facility) {
@@ -28,7 +28,6 @@ public record FacilityResponse(
             .allowedBoundary(facility.getAllowedBoundary())
             .supportFacilities(facility.getSupportFacilities())
             .pic(facility.getPic())
-            .possibleTimes(facility.getPossibleTimes())
             .build();
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -2,7 +2,6 @@ package com.example.rentalSystem.domain.facility.entity;
 
 import com.example.rentalSystem.domain.common.BaseTimeEntity;
 import com.example.rentalSystem.domain.facility.convert.StringListConverter;
-import com.example.rentalSystem.domain.facility.convert.WeekScheduleListConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -10,8 +10,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -52,11 +52,17 @@ public class Facility extends BaseTimeEntity {
     @Column
     private String pic; // 책임자
 
-    @Convert(converter = WeekScheduleListConverter.class)
-    private Map<String, List<String>> possibleTimes;
+    @Column
+    private LocalTime startTime;
+
+    @Column
+    private LocalTime endTime;
 
     @Column
     private boolean isAvailable;
+
+    @Column
+    private boolean isDeleted;
 
     @Builder
     public Facility(
@@ -67,7 +73,8 @@ public class Facility extends BaseTimeEntity {
         String allowedBoundary,
         List<String> supportFacilities,
         String pic,
-        Map<String, List<String>> possibleTimes,
+        LocalTime startTime,
+        LocalTime endTime,
         boolean isAvailable) {
 
         this.name = name;
@@ -77,8 +84,10 @@ public class Facility extends BaseTimeEntity {
         this.allowedBoundary = allowedBoundary;
         this.supportFacilities = supportFacilities;
         this.pic = pic;
-        this.possibleTimes = possibleTimes;
+        this.startTime = startTime;
+        this.endTime = endTime;
         this.isAvailable = isAvailable;
+        this.isDeleted = false;
     }
 
     public void update(Facility updateFacility) {

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/RentalStatus.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/RentalStatus.java
@@ -1,0 +1,12 @@
+package com.example.rentalSystem.domain.facility.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum RentalStatus {
+    AVAILABLE("예약가능"), UNAVAILABLE("이용불가"), RESERVED("예약완료"), WAITING("예약대기"), CURRENT("현재예약");
+    final String description;
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/TimeSlot.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/TimeSlot.java
@@ -1,0 +1,20 @@
+package com.example.rentalSystem.domain.facility.entity;
+
+import java.time.LocalTime;
+import java.util.LinkedHashMap;
+import lombok.Builder;
+
+@Builder
+public record TimeSlot(
+    LinkedHashMap<LocalTime, RentalStatus> timeSlot
+) {
+
+    public static TimeSlot createTimeSlot(LocalTime startTime, LocalTime endTime) {
+        LinkedHashMap<LocalTime, RentalStatus> timeSlot = new LinkedHashMap<>();
+        while (startTime.isBefore(endTime)) {
+            timeSlot.put(startTime, RentalStatus.AVAILABLE);
+            startTime = startTime.plusMinutes(30);
+        }
+        return TimeSlot.builder().timeSlot(timeSlot).build();
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/TimeTable.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/TimeTable.java
@@ -1,0 +1,57 @@
+package com.example.rentalSystem.domain.facility.entity;
+
+
+import com.example.rentalSystem.domain.facility.convert.TimeSlotConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class TimeTable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    private Facility facility;
+
+    @Column
+    private LocalDate today;
+
+    @Convert(converter = TimeSlotConverter.class)
+    private TimeSlot timeSlot;
+
+    @Builder
+    public TimeTable(
+        Facility facility,
+        LocalDate today,
+        TimeSlot timeSlot
+    ) {
+        this.facility = facility;
+        this.today = today;
+        this.timeSlot = timeSlot;
+    }
+
+    public static TimeTable toEntity(
+        Facility facility,
+        LocalDate today, LocalTime startTime,
+        LocalTime endTime) {
+        TimeSlot timeSlot = TimeSlot.createTimeSlot(startTime, endTime);
+
+        return TimeTable.builder()
+            .facility(facility)
+            .today(today)
+            .timeSlot(timeSlot)
+            .build();
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/reposiotry/TimeTableRepository.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/reposiotry/TimeTableRepository.java
@@ -1,0 +1,10 @@
+package com.example.rentalSystem.domain.facility.reposiotry;
+
+import com.example.rentalSystem.domain.facility.entity.TimeTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
+
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
@@ -7,16 +7,13 @@ import com.example.rentalSystem.domain.facility.dto.response.PresignUrlListRespo
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.facility.entity.TimeTable;
 import com.example.rentalSystem.domain.facility.implement.FacilityFinder;
-import com.example.rentalSystem.domain.facility.implement.FacilityReader;
 import com.example.rentalSystem.domain.facility.implement.FacilityRemover;
 import com.example.rentalSystem.domain.facility.implement.FacilitySaver;
 import com.example.rentalSystem.domain.facility.reposiotry.FacilityJpaRepository;
 import com.example.rentalSystem.domain.facility.reposiotry.TimeTableRepository;
 import com.example.rentalSystem.global.cloud.S3Service;
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class FacilityService {
 
-    private final FacilityReader facilityReader;
     private final FacilityJpaRepository facilityJpaRepository;
     private final TimeTableRepository timeTableRepository;
     private final FacilitySaver facilitySaver;


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->
시설 등록 api를 통해 시설을 등록을 할 때, 그 시설을 사용할 수 있는 시간을 같이 받습니다.
그리고 그 시설은 매주마다 시간표나 일정에 따라서 대여할 수 있는 시간이 달라집니다. 
그것을 기록하고 관리하기 위해서 시설 엔터티가 TimeTable이라는 자식 엔터티를 가져, 하루에 하나씩 row가 생기고 그 row 안에는 날짜와, 가능한 시간을 30분단위로 나누고 상태를 가진 Map 형태의 자료구조를 가지고 있습니다.

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- []
- [ ]

# 기타 (논의하고 싶은 부분)
TimeTable안에 TimeSlot이라는 클래스를 만들었습니다.
TimeSlot은 30분단위의 시간과 그 시간대의 상태를 저장하는 클래스인데, 이것을 그냥 TimeTable안에 LinkedHashMap으로 필드를 가질 지 
클래스로 뺼지 고민됩니다.
# 타 직군 전달 사항
30분 단위의 시간대로 관리하기 때문에 시각적인 타임테이블도 30분 단위로 해주셔야 할 것 같습니다!
close #이슈번호
#42 