### PR TITLE
Facility

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/email/controller/EmailController.java
+++ b/src/main/java/com/example/rentalSystem/domain/email/controller/EmailController.java
@@ -9,13 +9,9 @@ import com.example.rentalSystem.global.response.ApiResponse;
 import com.example.rentalSystem.global.response.SuccessType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.Mapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,23 +21,19 @@ public class EmailController {
 
     private final EmailService emailService;
 
-
     @PostMapping("/check-duplicate")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<?> checkDuplicatedEmail(@Valid @RequestBody EmailRequest emailRequest) {
         emailService.checkDuplicatedEmail(emailRequest);
         return ApiResponse.success(SuccessType.SUCCESS);
     }
 
     @PostMapping("/send-code")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<?> sendCodeToEmail(@Valid @RequestBody EmailRequest emailRequest) {
         emailService.sendCodeToEmail(emailRequest);
         return ApiResponse.success(SuccessType.SUCCESS);
     }
 
     @PostMapping("/check-code")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<?> checkCode(@RequestBody AuthCodeRequest authCodeRequest) {
         EmailVerificationResult emailVerificationResult = emailService.verificationCode(
             authCodeRequest.email(), authCodeRequest.authCode());

--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
@@ -11,7 +11,6 @@ import com.example.rentalSystem.global.response.SuccessType;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,35 +29,31 @@ public class FacilityController {
     private final FacilityService facilityService;
 
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<?> createFacility(@RequestBody CreateFacilityRequestDto requestDto) {
+    public ApiResponse<PresignUrlListResponse> createFacility(
+        @RequestBody CreateFacilityRequestDto requestDto) {
         PresignUrlListResponse presignUrlListResponse = facilityService.create(requestDto);
         return ApiResponse.success(SuccessType.CREATED, presignUrlListResponse);
     }
 
     @PutMapping("/{facilityId}")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<?> updateFacility(UpdateFacilityRequestDto requestDto, Long facilityId) {
         facilityService.update(requestDto, facilityId);
         return ApiResponse.success(SuccessType.SUCCESS);
     }
 
     @DeleteMapping("/{facilityId}")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<?> deleteFacility(Long facilityId) {
         facilityService.delete(facilityId);
         return ApiResponse.success(SuccessType.SUCCESS);
     }
 
     @GetMapping
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<List<FacilityResponse>> getAllFacility() {
         List<FacilityResponse> facilityResponses = facilityService.getAll();
         return ApiResponse.success(SuccessType.SUCCESS, facilityResponses);
     }
 
     @GetMapping("/{facilityId}")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<FacilityDetailResponse> getFacilityDetail(
         @PathVariable("facilityId") Long facilityId,
         @RequestParam(name = "date") LocalDate date

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
@@ -2,11 +2,13 @@ package com.example.rentalSystem.domain.facility.dto.request;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.facility.entity.FacilityType;
+import com.example.rentalSystem.global.exception.custom.CustomException;
+import com.example.rentalSystem.global.response.ErrorType;
 import java.time.LocalTime;
 import java.util.List;
 
 public record CreateFacilityRequestDto(
-    FacilityType facilityType,
+    String facilityType,
     String facilityNumber,
     List<String> fileNames,
     Long capacity,
@@ -19,17 +21,20 @@ public record CreateFacilityRequestDto(
 ) {
 
     public Facility toFacility(List<String> imageUrlList) {
-        return Facility.builder()
-            .facilityType(facilityType)
-            .facilityNumber(facilityNumber)
-            .images(imageUrlList)
-            .capacity(capacity)
-            .allowedBoundary(allowedBoundary)
-            .supportFacilities(supportFacilities)
-            .pic(pic)
-            .startTime(startTime)
-            .endTime(endTime)
-            .isAvailable(isAvailable)
-            .build();
+        if (FacilityType.existsByValue(facilityType)) {
+            return Facility.builder()
+                .facilityType(facilityType)
+                .facilityNumber(facilityNumber)
+                .images(imageUrlList)
+                .capacity(capacity)
+                .allowedBoundary(allowedBoundary)
+                .supportFacilities(supportFacilities)
+                .pic(pic)
+                .startTime(startTime)
+                .endTime(endTime)
+                .isAvailable(isAvailable)
+                .build();
+        }
+        throw new CustomException(ErrorType.INVALID_REQUEST);
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/UpdateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/UpdateFacilityRequestDto.java
@@ -2,11 +2,13 @@ package com.example.rentalSystem.domain.facility.dto.request;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.facility.entity.FacilityType;
+import com.example.rentalSystem.global.exception.custom.CustomException;
+import com.example.rentalSystem.global.response.ErrorType;
 import java.time.LocalTime;
 import java.util.List;
 
 public record UpdateFacilityRequestDto(
-    FacilityType facilityType,
+    String facilityType,
     String facilityNumber,
     String location,
     String chargeProfessor,
@@ -19,12 +21,15 @@ public record UpdateFacilityRequestDto(
 ) {
 
     public Facility toFacility() {
-        return Facility.builder()
-            .facilityType(this.facilityType)
-            .capacity(this.capacity)
-            .facilityNumber(facilityNumber)
-            .supportFacilities(supportFacilities)
-            .isAvailable(isAvailable)
-            .build();
+        if (FacilityType.existsByValue(facilityType)) {
+            return Facility.builder()
+                .facilityType((facilityType))
+                .capacity(capacity)
+                .facilityNumber(facilityNumber)
+                .supportFacilities(supportFacilities)
+                .isAvailable(isAvailable)
+                .build();
+        }
+        throw new CustomException(ErrorType.INVALID_REQUEST);
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -64,7 +64,7 @@ public class Facility extends BaseTimeEntity {
 
     @Builder
     public Facility(
-        FacilityType facilityType,
+        String facilityType,
         String facilityNumber,
         List<String> images,
         Long capacity,
@@ -75,7 +75,7 @@ public class Facility extends BaseTimeEntity {
         LocalTime endTime,
         boolean isAvailable) {
 
-        this.facilityType = facilityType.getKoreanName();
+        this.facilityType = facilityType;
         this.facilityNumber = facilityNumber;
         this.images = images;
         this.capacity = capacity;

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/FacilityType.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/FacilityType.java
@@ -3,9 +3,7 @@ package com.example.rentalSystem.domain.facility.entity;
 import com.example.rentalSystem.global.exception.custom.CustomException;
 import com.example.rentalSystem.global.response.ErrorType;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -20,13 +18,19 @@ public enum FacilityType {
     LIBRARY("도서관"),
     OUTDOOR("야외");
 
-    private final String koreanName;
+    private final String value;
 
-    @JsonCreator
-    public static FacilityType fromKoreanName(String koreanNane) {
+//    @JsonCreator
+//    public static FacilityType fromKoreanName(String value) {
+//        return Arrays.stream(values())
+//            .filter(type -> type.value.equals(value))
+//            .findAny()
+//            .orElseThrow(() -> new CustomException(ErrorType.INVALID_REQUEST));
+//    }
+
+    public static boolean existsByValue(String value) {
         return Arrays.stream(values())
-            .filter(type -> type.koreanName.equals(koreanNane))
-            .findAny()
-            .orElseThrow(() -> new CustomException(ErrorType.INVALID_REQUEST));
+            .anyMatch(type -> type.value.equals(value));
     }
+
 }

--- a/src/main/java/com/example/rentalSystem/domain/student/controller/StudentController.java
+++ b/src/main/java/com/example/rentalSystem/domain/student/controller/StudentController.java
@@ -12,13 +12,11 @@ import com.example.rentalSystem.global.response.ApiResponse;
 import com.example.rentalSystem.global.response.SuccessType;
 import com.example.rentalSystem.global.auth.jwt.entity.JwtToken;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,7 +27,6 @@ public class StudentController {
     private final StudentService studentService;
 
     @PostMapping("/sign-up")
-    @ResponseStatus(HttpStatus.CREATED)
     public ApiResponse<StudentSignUpResponse> signUp(
         @RequestBody StudentSignUpRequest signUpDto) {
         StudentSignUpResponse studentSignUpResponse = studentService.studentSignUp(signUpDto);
@@ -37,7 +34,6 @@ public class StudentController {
     }
 
     @PostMapping("/sign-in")
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<JwtToken> signIn(
         @RequestBody StudentSignInRequest studentSignInRequest) {
         JwtToken jwtToken = studentService.userSignIn(studentSignInRequest);
@@ -45,7 +41,6 @@ public class StudentController {
     }
 
     @GetMapping
-    @ResponseStatus(HttpStatus.OK)
     public ApiResponse<StudentListResponse> retrieveAllStudent() {
         return ApiResponse.success(SuccessType.SUCCESS, studentService.retrieveAllStudent());
     }


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->
1.  Dto안에 존재하는 enum -> String, enum 클래스 내부에 로직 메서드 추가
2. ApiResponse와 @ResponseStatus의 중복된 값을 제거하기 위해 @ResponseStatus 제거
# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [d0da833f1f510952940860ada30690dac921eace ]
ApiResponse와 @ResponseStatus의 중복된 값을 제거하기 위해 @ResponseStatus 제거
-  [13a8111313cb75db85081c59d92e7f51a4b1968a]
Dto안에 enum이 존재하면 dto와 도메인의 결합도가 높아지기 때문에 Dto는 데이터를 담는 역할만 하도록 하여 서비스 로직안에서 검사하도록 변경

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호