### PR TITLE
[refactor/feat] Student의 대학,전공, Facility의 FacilityType 필드를 String에서 Enum으로 변경 / 시설 타입별 시설 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/affiliation/converter/AffiliationConverter.java
+++ b/src/main/java/com/example/rentalSystem/domain/affiliation/converter/AffiliationConverter.java
@@ -1,0 +1,20 @@
+package com.example.rentalSystem.domain.affiliation.converter;
+
+import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
+import jakarta.persistence.AttributeConverter;
+
+public class AffiliationConverter implements AttributeConverter<AffiliationType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(AffiliationType affiliationType) {
+        if (affiliationType == null) {
+            return null;
+        }
+        return affiliationType.getName();
+    }
+
+    @Override
+    public AffiliationType convertToEntityAttribute(String name) {
+        return AffiliationType.getInstance(name);
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
+++ b/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
@@ -55,19 +55,9 @@ public enum AffiliationType {
     private final String name;
     private final AffiliationType parent;  // 상위 단과대
 
-    public static String existMajorByValue(String major) {
+    public static AffiliationType getInstance(String name) {
         return Arrays.stream(values())
-            .filter(type -> type.name.equals(major))
-            .map(type -> type.name) // 존재하면 value 반환
-            .findFirst()
-            .orElseThrow(
-                () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
-    }
-
-    public static String existCollegeByValue(String college) {
-        return Arrays.stream(values())
-            .filter(type -> type.name.equals(college))
-            .map(type -> type.name) // 존재하면 value 반환
+            .filter(type -> type.name.equals(name))
             .findFirst()
             .orElseThrow(
                 () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
@@ -80,8 +70,5 @@ public enum AffiliationType {
             .findFirst()
             .orElseThrow(
                 () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
-    }
-
-    public static AffiliationType getInstance(String name) {
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
+++ b/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
@@ -1,0 +1,87 @@
+package com.example.rentalSystem.domain.affiliation.type;
+
+import com.example.rentalSystem.global.exception.custom.CustomException;
+import com.example.rentalSystem.global.response.ErrorType;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AffiliationType {
+    // 총학
+    STUDENT_COUNCIL(1, "총학", "총학생회", null),
+
+    // 인문대
+    HUMANITIES(2, "단과대", "인문대학", null),
+    KOREAN_LANGUAGE_AND_LITERATURE(3, "학과", "국어국문학과", HUMANITIES),
+    CREATIVE_WRITING(4, "학과", "문예창작학과", HUMANITIES),
+    ENGLISH_LANGUAGE_AND_LITERATURE(5, "학과", "영어영문학과", HUMANITIES),
+    CHINESE_LANGUAGE_AND_LITERATURE(6, "학과", "중어중문학과", HUMANITIES),
+    JAPANESE_LANGUAGE_AND_LITERATURE(7, "학과", "일어일문학과", HUMANITIES),
+    LIBRARY_AND_INFORMATION_SCIENCE(8, "학과", "문헌정보학과", HUMANITIES),
+    ART_HISTORY(9, "학과", "미술사학과", HUMANITIES),
+    ARABIC_STUDIES(10, "학과", "아랍지역학과", HUMANITIES),
+    HISTORY(11, "학과", "사학과", HUMANITIES),
+    PHILOSOPHY(12, "학과", "철학과", HUMANITIES),
+
+    // 사회과학대
+    SOCIAL_SCIENCE(13, "단과대", "사회과학대학", null),
+    PUBLIC_ADMINISTRATION(14, "학과", "행정학과", SOCIAL_SCIENCE),
+    ECONOMICS(15, "학과", "경제학과", SOCIAL_SCIENCE),
+    POLITICAL_SCIENCE_AND_DIPLOMACY(16, "학과", "정치외교학과", SOCIAL_SCIENCE),
+    DIGITAL_MEDIA(17, "학과", "디지털미디어학과", SOCIAL_SCIENCE),
+    CHILD_STUDIES(18, "학과", "아동학과", SOCIAL_SCIENCE),
+    YOUTH_GUIDANCE(19, "학과", "청소년지도학과", SOCIAL_SCIENCE),
+
+    // 경영대
+    BUSINESS(20, "단과대", "경영대학", null),
+    BUSINESS_ADMINISTRATION(21, "학과", "경영학과", BUSINESS),
+    MANAGEMENT_INFORMATION_SYSTEMS(22, "학과", "경영정보학과", BUSINESS),
+    INTERNATIONAL_TRADE(23, "학과", "국제통상학과", BUSINESS),
+
+    // 법대
+    LAW(24, "단과대", "법학대학", null),
+    DEPARTMENT_OF_LAW(25, "학과", "법학과", LAW),
+
+    // ICT융합대
+    ICT(26, "단과대", "ICT융합대학", null),
+    DIGITAL_CONTENTS_DESIGN(27, "학과", "디지털콘텐츠디자인학과", ICT),
+    SOFTWARE_APPLICATIONS(28, "학과", "응용소프트웨어전공", ICT),
+    DATA_TECHNOLOGY(29, "학과", "데이터테크놀로지전공", ICT);
+
+    private final int val;
+    private final String councilType;
+    private final String name;
+    private final AffiliationType parent;  // 상위 단과대
+
+    public static String existMajorByValue(String major) {
+        return Arrays.stream(values())
+            .filter(type -> type.name.equals(major))
+            .map(type -> type.name) // 존재하면 value 반환
+            .findFirst()
+            .orElseThrow(
+                () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
+    }
+
+    public static String existCollegeByValue(String college) {
+        return Arrays.stream(values())
+            .filter(type -> type.name.equals(college))
+            .map(type -> type.name) // 존재하면 value 반환
+            .findFirst()
+            .orElseThrow(
+                () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
+    }
+
+    public static String getCollegeByMajor(String major) {
+        return Arrays.stream(values())
+            .filter(type -> type.name.equals(major))
+            .map(type -> type.parent.name) // 존재하면 value 반환
+            .findFirst()
+            .orElseThrow(
+                () -> new CustomException(ErrorType.INVALID_AFFILIATION_TYPE)); // 없으면 예외 발생
+    }
+
+    public static AffiliationType getInstance(String name) {
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityController.java
@@ -11,6 +11,9 @@ import com.example.rentalSystem.global.response.SuccessType;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,8 +51,11 @@ public class FacilityController {
     }
 
     @GetMapping
-    public ApiResponse<List<FacilityResponse>> getAllFacility() {
-        List<FacilityResponse> facilityResponses = facilityService.getAll();
+    public ApiResponse<Page<FacilityResponse>> getAllFacility(
+        @PageableDefault(size = 10) Pageable pageable,
+        @RequestParam(value = "facility-type", required = false) String facilityType
+    ) {
+        Page<FacilityResponse> facilityResponses = facilityService.getAll(pageable, facilityType);
         return ApiResponse.success(SuccessType.SUCCESS, facilityResponses);
     }
 

--- a/src/main/java/com/example/rentalSystem/domain/facility/convert/FacilityTypeConverter.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/convert/FacilityTypeConverter.java
@@ -1,0 +1,20 @@
+package com.example.rentalSystem.domain.facility.convert;
+
+import com.example.rentalSystem.domain.facility.entity.FacilityType;
+import jakarta.persistence.AttributeConverter;
+
+public class FacilityTypeConverter implements AttributeConverter<FacilityType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(FacilityType facilityType) {
+        if (facilityType == null) {
+            return null;
+        }
+        return facilityType.getValue();
+    }
+
+    @Override
+    public FacilityType convertToEntityAttribute(String value) {
+        return FacilityType.getInstanceByValue(value);
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
@@ -1,19 +1,26 @@
 package com.example.rentalSystem.domain.facility.dto.request;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import java.util.List;
 
 public record CreateFacilityRequestDto(
+    @NotEmpty
     String facilityType,
+    @NotEmpty
     String facilityNumber,
     List<String> fileNames,
+    @NotNull
     Long capacity,
-    String allowedBoundary,
     List<String> supportFacilities,
+    @NotEmpty
     String pic,
     LocalTime startTime,
     LocalTime endTime,
+    @NotEmpty
+    String college,
     boolean isAvailable
 ) {
 
@@ -23,12 +30,12 @@ public record CreateFacilityRequestDto(
             .facilityNumber(facilityNumber)
             .images(imageUrlList)
             .capacity(capacity)
-            .allowedBoundary(allowedBoundary)
             .supportFacilities(supportFacilities)
             .pic(pic)
             .startTime(startTime)
             .endTime(endTime)
             .isAvailable(isAvailable)
+            .college(college)
             .build();
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityDetailResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityDetailResponse.java
@@ -28,11 +28,10 @@ public record FacilityDetailResponse(
         return FacilityDetailResponse
             .builder()
             .id(facility.getId())
-            .facilityType(facility.getFacilityType())
+            .facilityType(facility.getFacilityTypeValue())
             .facilityNumber(facility.getFacilityNumber())
             .images(facility.getImages())
             .capacity(facility.getCapacity())
-            .allowedBoundary(facility.getAllowedBoundary())
             .supportFacilities(facility.getSupportFacilities())
             .pic(facility.getPic())
             .date(timeTable.getDate().toString())

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
@@ -1,6 +1,7 @@
 package com.example.rentalSystem.domain.facility.dto.response;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.rentalhistory.entity.RentalHistory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
@@ -24,19 +25,19 @@ public record FacilityResponse(
     public static FacilityResponse fromFacility(Facility facility) {
         return FacilityResponse.builder()
             .id(facility.getId())
-            .facilityType(facility.getFacilityType())
+            .facilityType(facility.getFacilityTypeValue())
             .facilityNumber(facility.getFacilityNumber())
             .images(facility.getImages())
             .capacity(facility.getCapacity())
-            .allowedBoundary(facility.getAllowedBoundary())
             .supportFacilities(facility.getSupportFacilities())
             .pic(facility.getPic())
             .build();
     }
 
-    public static FacilityResponse fromRentalHistory(Facility facility) {
+    public static FacilityResponse fromRentalHistory(RentalHistory rentalHistory) {
+        Facility facility = rentalHistory.getFacility();
         return FacilityResponse.builder()
-            .facilityType(facility.getFacilityType())
+            .facilityType(facility.getFacilityTypeValue())
             .facilityType(facility.getFacilityNumber())
             .build();
     }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -1,6 +1,9 @@
 package com.example.rentalSystem.domain.facility.entity;
 
+import com.example.rentalSystem.domain.affiliation.converter.AffiliationConverter;
+import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.common.BaseTimeEntity;
+import com.example.rentalSystem.domain.facility.convert.FacilityTypeConverter;
 import com.example.rentalSystem.domain.facility.convert.StringListConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -30,7 +33,8 @@ public class Facility extends BaseTimeEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String facilityType;
+    @Convert(converter = FacilityTypeConverter.class)
+    private FacilityType facilityType;
 
     @Column(nullable = false)
     private String facilityNumber;
@@ -40,9 +44,6 @@ public class Facility extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long capacity;
-
-    @Column(nullable = false)
-    private String allowedBoundary;
 
     @Convert(converter = StringListConverter.class)
     private List<String> supportFacilities;
@@ -62,28 +63,32 @@ public class Facility extends BaseTimeEntity {
     @Column
     private String pic; // 책임자
 
+    @Column
+    @Convert(converter = AffiliationConverter.class)
+    private AffiliationType college;
+
     @Builder
     public Facility(
         String facilityType,
         String facilityNumber,
         List<String> images,
         Long capacity,
-        String allowedBoundary,
         List<String> supportFacilities,
         String pic,
         LocalTime startTime,
         LocalTime endTime,
+        String college,
         boolean isAvailable) {
-        this.facilityType = FacilityType.existsByValue(facilityType);
+        this.facilityType = FacilityType.getInstanceByValue(facilityType);
         this.facilityNumber = facilityNumber;
         this.images = images;
         this.capacity = capacity;
-        this.allowedBoundary = allowedBoundary;
         this.supportFacilities = supportFacilities;
         this.pic = pic;
         this.startTime = startTime;
         this.endTime = endTime;
         this.isAvailable = isAvailable;
+        this.college = AffiliationType.getInstance(college);
         this.isDeleted = false;
     }
 
@@ -93,6 +98,11 @@ public class Facility extends BaseTimeEntity {
         this.images = updateFacility.getImages();
         this.capacity = updateFacility.getCapacity();
         this.supportFacilities = updateFacility.getSupportFacilities();
+        this.college = updateFacility.getCollege();
         this.isAvailable = updateFacility.isAvailable();
+    }
+
+    public String getFacilityTypeValue() {
+        return facilityType.getValue();
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/FacilityType.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/FacilityType.java
@@ -2,7 +2,6 @@ package com.example.rentalSystem.domain.facility.entity;
 
 import com.example.rentalSystem.global.exception.custom.CustomException;
 import com.example.rentalSystem.global.response.ErrorType;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,17 +19,9 @@ public enum FacilityType {
 
     private final String value;
 
-    //    @JsonCreator
-//    public static FacilityType fromKoreanName(String value) {
-//        return Arrays.stream(values())
-//            .filter(type -> type.value.equals(value))
-//            .findAny()
-//            .orElseThrow(() -> new CustomException(ErrorType.INVALID_REQUEST));
-//    }
-    public static String existsByValue(String value) {
+    public static FacilityType getInstanceByValue(String value) {
         return Arrays.stream(values())
             .filter(type -> type.value.equals(value))
-            .map(type -> type.value) // 존재하면 value 반환
             .findFirst()
             .orElseThrow(() -> new CustomException(ErrorType.INVALID_FACILITY_TYPE)); // 없으면 예외 발생
     }

--- a/src/main/java/com/example/rentalSystem/domain/facility/reposiotry/FacilityJpaRepository.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/reposiotry/FacilityJpaRepository.java
@@ -1,9 +1,12 @@
 package com.example.rentalSystem.domain.facility.reposiotry;
 
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.facility.entity.FacilityType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FacilityJpaRepository extends JpaRepository<Facility, Long> {
 
-//  Optional<Facility> findByNameAndLocation(String name, String location);
+    Page<Facility> findByFacilityType(FacilityType instanceByValue, Pageable pageable);
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
@@ -6,6 +6,7 @@ import com.example.rentalSystem.domain.facility.dto.response.FacilityDetailRespo
 import com.example.rentalSystem.domain.facility.dto.response.FacilityResponse;
 import com.example.rentalSystem.domain.facility.dto.response.PresignUrlListResponse;
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.facility.entity.FacilityType;
 import com.example.rentalSystem.domain.facility.entity.timeTable.TimeTable;
 import com.example.rentalSystem.domain.facility.implement.FacilityFinder;
 import com.example.rentalSystem.domain.facility.implement.FacilityRemover;
@@ -16,7 +17,10 @@ import com.example.rentalSystem.global.cloud.S3Service;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,12 +81,17 @@ public class FacilityService {
         facilityRemover.delete(facility);
     }
 
-    public List<FacilityResponse> getAll() {
-        List<Facility> facilities = facilityJpaRepository.findAll();
-
-        return facilities.stream()
-            .map(FacilityResponse::fromFacility)
-            .toList();
+    public Page<FacilityResponse> getAll(Pageable pageable, String facilityType) {
+        Page<Facility> facilities;
+        if (Objects.isNull(facilityType)) {
+            facilities = facilityJpaRepository.findAll(pageable);
+        } else {
+            facilities = facilityJpaRepository.findByFacilityType(
+                FacilityType.getInstanceByValue(facilityType),
+                pageable);
+        }
+        return facilities
+            .map(FacilityResponse::fromFacility);
     }
 
     public FacilityDetailResponse getFacilityDetail(Long facilityId, LocalDate localDate) {

--- a/src/main/java/com/example/rentalSystem/domain/student/service/StudentService.java
+++ b/src/main/java/com/example/rentalSystem/domain/student/service/StudentService.java
@@ -57,6 +57,6 @@ public class StudentService {
         String email) {
         Student student = studentFinder.findByEmail(email);
         student.updateInfo(studentUpdateRequest.name(), studentUpdateRequest.major());
-        return StudentUpdateResponse.of(student.getName(), student.getMajor());
+        return StudentUpdateResponse.of(student.getName(), student.getMajorName());
     }
 }

--- a/src/main/java/com/example/rentalSystem/global/response/ErrorType.java
+++ b/src/main/java/com/example/rentalSystem/global/response/ErrorType.java
@@ -21,7 +21,8 @@ public enum ErrorType {
     INVALID_REQUEST(400, "형식에 맞지 않는 요청입니다."),
     DUPLICATE_SEND(409, "인증 코드가 발송되어 있습니다."),
     FAIL_RENTAL_REQUEST(409, "예약 신청이 불가능한 시간입니다."),
-    INVALID_FACILITY_TYPE(400, "유효한 시설 타입이 아닙니다.");
+    INVALID_FACILITY_TYPE(400, "유효한 시설 타입이 아닙니다."),
+    INVALID_AFFILIATION_TYPE(400, "유효한 소속이 아닙니다.");
 
     private final int httpStatusCode;
     private final String message;


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->
1.  기존 생성자에 존재했던, enum 검증 메소드를 제거. @Converter를 사용하여, string으로 db에 저장하고, 엔터티는 enum 인스턴스로 관리하도록 변경
2. 시설 타입별 시설 전체 조회 api 구현
# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [ ]
- [ ]

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호