### PR TITLE
[Feat/Refactor] 엔터티간의 관계 변경

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/CreateFacilityRequestDto.java
@@ -16,8 +16,6 @@ public record CreateFacilityRequestDto(
     @NotNull
     Long capacity,
     List<String> supportFacilities,
-    @NotEmpty
-    String pic,
     LocalTime startTime,
     LocalTime endTime,
     @NotEmpty
@@ -32,7 +30,6 @@ public record CreateFacilityRequestDto(
             .images(imageUrlList)
             .capacity(capacity)
             .supportFacilities(supportFacilities)
-            .pic(pic)
             .startTime(startTime)
             .endTime(endTime)
             .isAvailable(isAvailable)

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityDetailResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityDetailResponse.java
@@ -33,7 +33,6 @@ public record FacilityDetailResponse(
             .images(facility.getImages())
             .capacity(facility.getCapacity())
             .supportFacilities(facility.getSupportFacilities())
-            .pic(facility.getPic())
             .date(timeTable.getDate().toString())
             .timeSlot(timeTable.getTimeSlot())
             .allowedBoundary(facility.getAllowedBoundary())

--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/response/FacilityResponse.java
@@ -30,7 +30,6 @@ public record FacilityResponse(
             .images(facility.getImages())
             .capacity(facility.getCapacity())
             .supportFacilities(facility.getSupportFacilities())
-            .pic(facility.getPic())
             .allowedBoundary(facility.getAllowedBoundary())
             .build();
     }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -63,9 +63,6 @@ public class Facility extends BaseTimeEntity {
     private boolean isDeleted;
 
     @Column
-    private String pic; // 책임자
-
-    @Column
     @Convert(converter = AffiliationListConverter.class)
     private List<AffiliationType> allowedBoundary;
 
@@ -76,7 +73,6 @@ public class Facility extends BaseTimeEntity {
         List<String> images,
         Long capacity,
         List<String> supportFacilities,
-        String pic,
         LocalTime startTime,
         LocalTime endTime,
         List<AffiliationType> allowedBoundary,
@@ -86,7 +82,6 @@ public class Facility extends BaseTimeEntity {
         this.images = images;
         this.capacity = capacity;
         this.supportFacilities = supportFacilities;
-        this.pic = pic;
         this.startTime = startTime;
         this.endTime = endTime;
         this.isAvailable = isAvailable;

--- a/src/main/java/com/example/rentalSystem/domain/member/entity/Member.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/entity/Member.java
@@ -40,13 +40,13 @@ public abstract class Member {
     private AffiliationType college;
 
     public Member(String email, Role role, String name,
-        String password, String phoneNumber, String major) {
+        String password, String phoneNumber, AffiliationType college) {
         this.email = email;
         this.role = role;
         this.name = name;
         this.password = password;
         this.phoneNumber = phoneNumber;
-        this.college = AffiliationType.getCollegeByMajor(major);
+        this.college = college;
     }
 
     public String getRoles() {

--- a/src/main/java/com/example/rentalSystem/domain/member/entity/Role.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/entity/Role.java
@@ -8,8 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum Role {
     STUDENT("ROLE_STUDENT"),
     PROFESSOR("ROLE_STUDENT,ROLE_PROFESSOR"),
-    ADMIN("ROLE_STUDENT,ROLE_PROFESSOR,ROLE_ADMIN");
-    
+    PIC("ROLE_STUDENT,ROLE_PROFESSOR,ROLE_PIC"),
+    ADMIN("ROLE_STUDENT,ROLE_PROFESSOR,ROLE_PIC,ROLE_ADMIN");
+
     private final String roles;
 
 }

--- a/src/main/java/com/example/rentalSystem/domain/pic/entity/Pic.java
+++ b/src/main/java/com/example/rentalSystem/domain/pic/entity/Pic.java
@@ -1,9 +1,24 @@
 package com.example.rentalSystem.domain.pic.entity;
 
+import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.member.entity.Member;
+import com.example.rentalSystem.domain.member.entity.Role;
 import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 
 @Entity
+@AllArgsConstructor
 public class Pic extends Member {
 
+    @Builder
+    public Pic(
+        String email,
+        Role role,
+        String name,
+        String password,
+        String phoneNumber,
+        String college) {
+        super(email, role, name, password, phoneNumber, AffiliationType.getInstance(college));
+    }
 }

--- a/src/main/java/com/example/rentalSystem/domain/pic/repository/PicRepository.java
+++ b/src/main/java/com/example/rentalSystem/domain/pic/repository/PicRepository.java
@@ -1,0 +1,10 @@
+package com.example.rentalSystem.domain.pic.repository;
+
+import com.example.rentalSystem.domain.pic.entity.Pic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PicRepository extends JpaRepository<Pic, Long> {
+
+}

--- a/src/main/java/com/example/rentalSystem/domain/professor/entity/Professor.java
+++ b/src/main/java/com/example/rentalSystem/domain/professor/entity/Professor.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +33,11 @@ public class Professor extends BaseTimeEntity {
     @Column(nullable = false)
     private String email;
 
+    @Builder
+    public Professor(Long id, String name, AffiliationType affiliationType, String email) {
+        this.id = id;
+        this.name = name;
+        this.affiliationType = affiliationType;
+        this.email = email;
+    }
 }

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Null;
 import java.time.LocalDateTime;
@@ -53,6 +54,10 @@ public class RentalHistory extends BaseTimeEntity {
 
     @ManyToOne
     private Facility facility;
+
+    @ManyToOne
+    @JoinColumn(name = "pic_id", nullable = false)
+    private Pic pic;
 
     @Builder
     public RentalHistory(

--- a/src/main/java/com/example/rentalSystem/domain/student/entity/Student.java
+++ b/src/main/java/com/example/rentalSystem/domain/student/entity/Student.java
@@ -29,7 +29,8 @@ public class Student extends Member {
     public Student(String studentNumber, String major, Long warningTime,
         String email, String name,
         String password, String phoneNumber) {
-        super(email, Role.STUDENT, name, password, phoneNumber, major);
+        super(email, Role.STUDENT, name, password, phoneNumber,
+            AffiliationType.getCollegeByMajor(major));
         this.studentNumber = studentNumber;
         this.major = AffiliationType.getInstance(major);
         this.warningTime = warningTime != null ? warningTime : 0L;  // 기본값 설정

--- a/src/main/java/com/example/rentalSystem/global/initializer/DataInitializer.java
+++ b/src/main/java/com/example/rentalSystem/global/initializer/DataInitializer.java
@@ -6,21 +6,18 @@ import com.example.rentalSystem.domain.pic.entity.Pic;
 import com.example.rentalSystem.domain.pic.repository.PicRepository;
 import com.example.rentalSystem.domain.professor.entity.Professor;
 import com.example.rentalSystem.domain.professor.repository.ProfessorRepository;
+import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
+@AllArgsConstructor
 public class DataInitializer implements CommandLineRunner {
 
-    @Autowired
     private PicRepository picRepository;
-
-    @Autowired
     private ProfessorRepository professorRepository;
-
-    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Override

--- a/src/test/java/com/example/rentalSystem/domain/facility/controller/FacilityControllerTest.java
+++ b/src/test/java/com/example/rentalSystem/domain/facility/controller/FacilityControllerTest.java
@@ -16,7 +16,7 @@ import com.example.rentalSystem.common.fixture.FacilityFixture;
 import com.example.rentalSystem.common.support.ApiTestSupport;
 import com.example.rentalSystem.domain.facility.dto.request.CreateFacilityRequestDto;
 import com.example.rentalSystem.domain.facility.dto.request.UpdateFacilityRequestDto;
-import com.example.rentalSystem.domain.facility.dto.response.PresignUrlListResponse;
+import com.example.rentalSystem.domain.facility.dto.response.PreSignUrlListResponse;
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.facility.service.FacilityService;
 import com.example.rentalSystem.global.response.ResultType;
@@ -50,7 +50,7 @@ class FacilityControllerTest extends ApiTestSupport {
     void 시설_생성_API() throws Exception {
         // Given
         CreateFacilityRequestDto requestDto = FacilityFixture.createFacilityRequestDto();
-        PresignUrlListResponse presignUrlListResponse = FacilityFixture.createFacilityResponseDto();
+        PreSignUrlListResponse presignUrlListResponse = FacilityFixture.createFacilityResponseDto();
 
         doReturn(presignUrlListResponse)
             .when(facilityService)


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

엔터티간의 관계 변경

# 작업 내용

기존 시설과 교직원간의 관계를 맺고 있었지만, 대여내역과 교직원이 관계를 맺는 것이 맞다고 생각하여 변경했습니다.

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [b0586ffb899d7f6ca477ab9222d1316941455631 ] 필드 주입을 피하고 생성자 주입을 하기 위해 @AllArgsConstructor로 변경
- [306623582424bae70a35898290af200a0b83b476 ]  RentalHistory에 pic를 조인한 모습. 하지만 foregin key인데 nullable이 되도록 해도 괜찮은 지 고민중에 있습니다.

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호