### PR TITLE
[Refactor/Feat] 응답값으로 enum값이 아닌 변수명으로 전달하도록 변경, 소속에 캠퍼스까지 추가

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
+++ b/src/main/java/com/example/rentalSystem/domain/affiliation/type/AffiliationType.java
@@ -2,6 +2,8 @@ package com.example.rentalSystem.domain.affiliation.type;
 
 import com.example.rentalSystem.global.exception.custom.CustomException;
 import com.example.rentalSystem.global.response.ErrorType;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
@@ -10,8 +12,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum AffiliationType {
+    SEOUL(0, "캠퍼스", "서울", null),
+
     // 총학
-    STUDENT_COUNCIL(1, "총학", "총학생회", null),
+    STUDENT_COUNCIL(1, "총학", "총학생회", SEOUL),
 
     // 인문대
     HUMANITIES(2, "단과대", "인문대학", null),

--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/dto/response/FacilityDetailResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/dto/response/FacilityDetailResponse.java
@@ -1,7 +1,8 @@
-package com.example.rentalSystem.domain.facility.dto.response;
+package com.example.rentalSystem.domain.facility.controller.dto.response;
 
 import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.facility.entity.FacilityType;
 import com.example.rentalSystem.domain.facility.entity.timeTable.TimeStatus;
 import com.example.rentalSystem.domain.facility.entity.timeTable.TimeTable;
 import java.time.LocalTime;
@@ -12,7 +13,7 @@ import lombok.Builder;
 @Builder
 public record FacilityDetailResponse(
     Long id,
-    String facilityType,
+    FacilityType facilityType,
     String facilityNumber,
     List<String> images,
     Long capacity,
@@ -28,7 +29,7 @@ public record FacilityDetailResponse(
         return FacilityDetailResponse
             .builder()
             .id(facility.getId())
-            .facilityType(facility.getFacilityTypeValue())
+            .facilityType(facility.getFacilityType())
             .facilityNumber(facility.getFacilityNumber())
             .images(facility.getImages())
             .capacity(facility.getCapacity())

--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/dto/response/FacilityResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/dto/response/FacilityResponse.java
@@ -1,7 +1,8 @@
-package com.example.rentalSystem.domain.facility.dto.response;
+package com.example.rentalSystem.domain.facility.controller.dto.response;
 
 import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.facility.entity.Facility;
+import com.example.rentalSystem.domain.facility.entity.FacilityType;
 import com.example.rentalSystem.domain.rentalhistory.entity.RentalHistory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -13,7 +14,7 @@ import lombok.Builder;
 public record FacilityResponse(
     //이미지
     Long id,
-    String facilityType,
+    FacilityType facilityType,
     String facilityNumber,
     List<String> images,
     Long capacity,
@@ -25,7 +26,7 @@ public record FacilityResponse(
     public static FacilityResponse fromFacility(Facility facility) {
         return FacilityResponse.builder()
             .id(facility.getId())
-            .facilityType(facility.getFacilityTypeValue())
+            .facilityType(facility.getFacilityType())
             .facilityNumber(facility.getFacilityNumber())
             .images(facility.getImages())
             .capacity(facility.getCapacity())
@@ -37,7 +38,7 @@ public record FacilityResponse(
     public static FacilityResponse fromRentalHistory(RentalHistory rentalHistory) {
         Facility facility = rentalHistory.getFacility();
         return FacilityResponse.builder()
-            .facilityType(facility.getFacilityTypeValue())
+            .facilityType(facility.getFacilityType())
             .facilityNumber(facility.getFacilityNumber())
             .build();
     }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/Facility.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.redis.connection.convert.ListConverter;
 
 @Entity
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 //@SQLDelete(sql = "update facility set is_deleted = true where id=?")
@@ -96,9 +97,5 @@ public class Facility extends BaseTimeEntity {
         this.capacity = updateFacility.getCapacity();
         this.supportFacilities = updateFacility.getSupportFacilities();
         this.isAvailable = updateFacility.isAvailable();
-    }
-
-    public String getFacilityTypeValue() {
-        return facilityType.getValue();
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/timeTable/TimeStatus.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/timeTable/TimeStatus.java
@@ -1,6 +1,5 @@
 package com.example.rentalSystem.domain.facility.entity.timeTable;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,10 +9,5 @@ import lombok.RequiredArgsConstructor;
 public enum TimeStatus {
     AVAILABLE("예약가능"), UNAVAILABLE("이용불가"), RESERVED("예약완료"), WAITING("예약대기"), CURRENT("현재예약");
     final String description;
-
-    @JsonValue
-    public String getDescription() {
-        return description;
-    }
 
 }

--- a/src/main/java/com/example/rentalSystem/domain/professor/entity/Professor.java
+++ b/src/main/java/com/example/rentalSystem/domain/professor/entity/Professor.java
@@ -26,17 +26,28 @@ public class Professor extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Convert(converter = AffiliationConverter.class)
+    private AffiliationType campusType;
+
     @Column(nullable = false)
     @Convert(converter = AffiliationConverter.class)
-    private AffiliationType affiliationType;
+    private AffiliationType college;
+
+    @Column(nullable = false)
+    @Convert(converter = AffiliationConverter.class)
+    private AffiliationType major;
 
     @Column(nullable = false)
     private String email;
 
     @Builder
-    public Professor(String name, AffiliationType affiliationType, String email) {
+    public Professor(String name, AffiliationType campusType, AffiliationType college,
+        AffiliationType major,
+        String email) {
         this.name = name;
-        this.affiliationType = affiliationType;
+        this.campusType = campusType;
+        this.college = college;
+        this.major = major;
         this.email = email;
     }
 }

--- a/src/main/java/com/example/rentalSystem/global/initializer/DataInitializer.java
+++ b/src/main/java/com/example/rentalSystem/global/initializer/DataInitializer.java
@@ -7,7 +7,6 @@ import com.example.rentalSystem.domain.pic.repository.PicRepository;
 import com.example.rentalSystem.domain.professor.entity.Professor;
 import com.example.rentalSystem.domain.professor.repository.ProfessorRepository;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -35,7 +34,9 @@ public class DataInitializer implements CommandLineRunner {
         }
         if (professorRepository.count() == 0) {
             Professor professor = Professor.builder()
-                .affiliationType(AffiliationType.ICT)
+                .campusType(AffiliationType.SEOUL)
+                .college(AffiliationType.ICT)
+                .major(AffiliationType.SOFTWARE_APPLICATIONS)
                 .email("professor@e.com")
                 .name("최성운")
                 .build();


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

응답값으로 enum값이 아닌 변수명으로 전달하도록 변경, 소속에 캠퍼스까지 추가
# 작업 내용
기존에는 응답값으로 enum의 변수가 아닌 값으로 전달하여 의미를 잘 전달하자 라는 생각을 헀었으나, 그렇게 하니 불필요한 코드가 계속 추가되는 것 같았습니다. 프론트에서도 바로 그것을 사용하는 것이 아닌 변수로 받아서 사용하기 때문에 enum의 장점을 살리고자 변수명을 전달하도록 변경했습니다.
<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [ ]
- [ ]

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호