### PR TITLE
[Feat] Swagger 에러 예시를 위한 커스텀 어노테이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
     //	validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/example/rentalSystem/domain/email/controller/EmailControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/email/controller/EmailControllerDocs.java
@@ -4,6 +4,9 @@ import com.example.rentalSystem.domain.email.controller.dto.request.AuthCodeRequ
 import com.example.rentalSystem.domain.email.controller.dto.request.EmailRequest;
 import com.example.rentalSystem.domain.email.controller.dto.response.EmailVerificationResult;
 import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
+import com.example.rentalSystem.global.response.type.ErrorType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -12,9 +15,13 @@ public interface EmailControllerDocs {
 
 
     @Operation(summary = "이메일 중복 확인", description = "이메일 중복시 예외 발생")
+    @ApiErrorCodeExample(ErrorType.DUPLICATE_EMAIL_RESOURCE)
     ApiResponse<?> checkDuplicatedEmail(EmailRequest emailRequest);
 
     @Operation(summary = "인증코드 발송", description = "이메일에 6자리 인증 코드 발송")
+    @ApiErrorCodeExamples(
+        {ErrorType.BAD_REQUEST, ErrorType.DUPLICATE_SEND, ErrorType.FAIL_SEND_EMAIL}
+    )
     ApiResponse<?> sendCodeToEmail(EmailRequest emailRequest);
 
     @Operation(summary = "인증코드 검증", description = "인증 코드 6자리가 맞는 지 확인")

--- a/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/controller/FacilityControllerDocs.java
@@ -6,6 +6,9 @@ import com.example.rentalSystem.domain.facility.controller.dto.response.Facility
 import com.example.rentalSystem.domain.facility.controller.dto.response.FacilityResponse;
 import com.example.rentalSystem.domain.facility.controller.dto.response.PreSignUrlListResponse;
 import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
+import com.example.rentalSystem.global.response.type.ErrorType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
@@ -18,18 +21,22 @@ public interface FacilityControllerDocs {
     @Operation(summary = "시설 등록 API")
     ApiResponse<PreSignUrlListResponse> createFacility(CreateFacilityRequestDto requestDto);
 
+    @ApiErrorCodeExample(ErrorType.ENTITY_NOT_FOUND)
     @Operation(summary = "시설 수정 API")
     ApiResponse<?> updateFacility(UpdateFacilityRequestDto requestDto, Long facilityId);
 
     @Operation(summary = "시설 삭제 API")
+    @ApiErrorCodeExample(ErrorType.ENTITY_NOT_FOUND)
     ApiResponse<?> deleteFacility(Long facilityId);
 
     @Operation(summary = "시설 전체 조회 API")
+    @ApiErrorCodeExample(ErrorType.INVALID_FACILITY_TYPE)
     ApiResponse<Page<FacilityResponse>> getAllFacility(
         Pageable pageable, String facilityType
     );
 
     @Operation(summary = "시설 전체 상세 조회 API")
+    @ApiErrorCodeExample(ErrorType.ENTITY_NOT_FOUND)
     ApiResponse<FacilityDetailResponse> getFacilityDetail(
         Long facilityId, LocalDate date);
 }

--- a/src/main/java/com/example/rentalSystem/domain/professor/controller/ProfessorController.java
+++ b/src/main/java/com/example/rentalSystem/domain/professor/controller/ProfessorController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/professors")
-public class ProfessorController {
+public class ProfessorController implements ProfessorControllerDocs {
 
     private final ProfessorService professorService;
 

--- a/src/main/java/com/example/rentalSystem/domain/professor/controller/ProfessorControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/professor/controller/ProfessorControllerDocs.java
@@ -1,0 +1,20 @@
+package com.example.rentalSystem.domain.professor.controller;
+
+import com.example.rentalSystem.domain.professor.controller.dto.response.ProfessorDetailResponse;
+import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.type.SuccessType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "교수 관련 API", description = "교수 전체 조회 API")
+public interface ProfessorControllerDocs {
+
+    @Operation(summary = "교수 전체 조회 API")
+    ApiResponse<?> getAllProfessor(Pageable pageable, String campus, String college,
+        String major);
+
+}

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/RentalController.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/RentalController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,10 +23,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/rental")
-public class RentalController {
+public class RentalController implements RentalControllerDocs {
 
     final RentalService rentalService;
 
+    @Override
     @PostMapping()
     public ApiResponse<?> createRental(
         @AuthenticationPrincipal CustomerDetails customerDetails,
@@ -34,15 +36,17 @@ public class RentalController {
         return ApiResponse.success(SuccessType.CREATED);
     }
 
+    @Override
     @GetMapping()
     public ApiResponse<Page<RentalHistoryResponseDto>> getAllRentalHistory(
-        Pageable pageable) {
+        @PageableDefault Pageable pageable) {
         Page<RentalHistoryResponseDto> rentalHistoryResponseDtoList = rentalService.getAllRentalHistory(
             pageable);
 
         return ApiResponse.success(SuccessType.SUCCESS, rentalHistoryResponseDtoList);
     }
 
+    @Override
     @GetMapping("/students/{studentId}")
     public ApiResponse<?> getAllRentalHistoryByStudent(
         @PathVariable(name = "studentId") String studentId) {
@@ -51,6 +55,7 @@ public class RentalController {
         return ApiResponse.success(SuccessType.SUCCESS, rentalHistoryResponseDtoList);
     }
 
+    @Override
     @GetMapping("/{rentalHistoryId}")
     public ApiResponse<?> getRentalHistoryDetail(
         @PathVariable(name = "rentalHistoryId") String rentalHistoryId

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/RentalControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/RentalControllerDocs.java
@@ -1,0 +1,42 @@
+package com.example.rentalSystem.domain.rentalhistory.controller;
+
+import static com.example.rentalSystem.global.response.type.ErrorType.ENTITY_NOT_FOUND;
+import static com.example.rentalSystem.global.response.type.ErrorType.FAIL_RENTAL_REQUEST;
+import static com.example.rentalSystem.global.response.type.ErrorType.FAIL_SEND_EMAIL;
+
+import com.example.rentalSystem.domain.member.entity.CustomerDetails;
+import com.example.rentalSystem.domain.rentalhistory.controller.dto.request.CreateRentalRequest;
+import com.example.rentalSystem.domain.rentalhistory.controller.dto.response.RentalHistoryResponseDto;
+import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "시설 대여에 관한 API", description = "시설 대여, 전체 대여 내역 조회, 시설 대여 내역 상세 조회, 학생 시설 대여 내역 조회")
+public interface RentalControllerDocs {
+
+    @Operation(summary = "시설 대여 신청")
+    @ApiErrorCodeExamples(
+        {FAIL_RENTAL_REQUEST, ENTITY_NOT_FOUND, FAIL_SEND_EMAIL}
+    )
+    ApiResponse<?> createRental(
+        CustomerDetails customerDetails,
+        CreateRentalRequest createRentalRequest);
+
+    @Operation(summary = "시설 대여 내역 전체 조회")
+    ApiResponse<Page<RentalHistoryResponseDto>> getAllRentalHistory(
+        Pageable pageable);
+
+    @Operation(summary = "학생 시설 대여 내역 전체 조회")
+    ApiResponse<?> getAllRentalHistoryByStudent(
+        String studentId);
+
+    @Operation(summary = "시설 대여 내역 상세 조회")
+    @ApiErrorCodeExample(ENTITY_NOT_FOUND)
+    ApiResponse<?> getRentalHistoryDetail(
+        String rentalHistoryId
+    );
+}

--- a/src/main/java/com/example/rentalSystem/domain/student/controller/StudentController.java
+++ b/src/main/java/com/example/rentalSystem/domain/student/controller/StudentController.java
@@ -22,10 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/students")
-public class StudentController {
+public class StudentController implements StudentControllerDocs {
 
     private final StudentService studentService;
 
+    @Override
     @PostMapping("/sign-up")
     public ApiResponse<StudentSignUpResponse> signUp(
         @RequestBody StudentSignUpRequest signUpDto) {
@@ -33,6 +34,7 @@ public class StudentController {
         return ApiResponse.success(SuccessType.CREATED, studentSignUpResponse);
     }
 
+    @Override
     @PostMapping("/sign-in")
     public ApiResponse<JwtToken> signIn(
         @RequestBody StudentSignInRequest studentSignInRequest) {
@@ -40,11 +42,13 @@ public class StudentController {
         return ApiResponse.success(SuccessType.SUCCESS, jwtToken);
     }
 
+    @Override
     @GetMapping
     public ApiResponse<StudentListResponse> retrieveAllStudent() {
         return ApiResponse.success(SuccessType.SUCCESS, studentService.retrieveAllStudent());
     }
 
+    @Override
     @PatchMapping
     public ApiResponse<?> updateStudentInfo(StudentUpdateRequest studentUpdateRequest,
         CustomerDetails customerDetails) {

--- a/src/main/java/com/example/rentalSystem/domain/student/controller/StudentControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/student/controller/StudentControllerDocs.java
@@ -1,0 +1,43 @@
+package com.example.rentalSystem.domain.student.controller;
+
+import static com.example.rentalSystem.global.response.type.ErrorType.DUPLICATE_EMAIL_RESOURCE;
+import static com.example.rentalSystem.global.response.type.ErrorType.ENTITY_NOT_FOUND;
+import static com.example.rentalSystem.global.response.type.ErrorType.FAIL_AUTHENTICATION;
+import static com.example.rentalSystem.global.response.type.ErrorType.INVALID_AFFILIATION_TYPE;
+
+import com.example.rentalSystem.domain.member.entity.CustomerDetails;
+import com.example.rentalSystem.domain.student.controller.dto.request.StudentSignInRequest;
+import com.example.rentalSystem.domain.student.controller.dto.request.StudentSignUpRequest;
+import com.example.rentalSystem.domain.student.controller.dto.request.StudentUpdateRequest;
+import com.example.rentalSystem.domain.student.controller.dto.response.StudentListResponse;
+import com.example.rentalSystem.domain.student.controller.dto.response.StudentSignUpResponse;
+import com.example.rentalSystem.global.auth.jwt.entity.JwtToken;
+import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "학생 관련 API")
+public interface StudentControllerDocs {
+
+    @Operation(summary = "회원가입 API")
+    @ApiErrorCodeExamples({
+        DUPLICATE_EMAIL_RESOURCE, INVALID_AFFILIATION_TYPE
+    })
+    ApiResponse<StudentSignUpResponse> signUp(StudentSignUpRequest signUpDto);
+
+    @Operation(summary = "로그인 API")
+    @ApiErrorCodeExamples({
+        FAIL_AUTHENTICATION,
+    })
+    ApiResponse<JwtToken> signIn(StudentSignInRequest studentSignInRequest);
+
+    @Operation(summary = "학생 전체 조회 API")
+    ApiResponse<StudentListResponse> retrieveAllStudent();
+
+    @Operation(summary = "학생 정보 수정 API")
+    @ApiErrorCodeExample(ENTITY_NOT_FOUND)
+    ApiResponse<?> updateStudentInfo(StudentUpdateRequest studentUpdateRequest,
+        CustomerDetails customerDetails);
+}

--- a/src/main/java/com/example/rentalSystem/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/rentalSystem/global/config/SwaggerConfig.java
@@ -1,13 +1,31 @@
 package com.example.rentalSystem.global.config;
 
+import static java.rmi.server.LogStream.log;
+
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
+import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
+import com.example.rentalSystem.global.response.example.ExampleHolder;
+import com.example.rentalSystem.global.response.type.ErrorType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
 
 @Configuration
 public class SwaggerConfig {
@@ -40,6 +58,98 @@ public class SwaggerConfig {
 //        );
 //    }
 
+    @Bean
+    public OperationCustomizer customizer() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            ApiErrorCodeExamples apiErrorCodeExamples = handlerMethod.getMethodAnnotation(
+                ApiErrorCodeExamples.class);
+
+            if (apiErrorCodeExamples != null) {
+                generateResponseCodeExample(operation, apiErrorCodeExamples.value());
+            } else {
+                ApiErrorCodeExample apiSuccessCodeExample = handlerMethod.getMethodAnnotation(
+                    ApiErrorCodeExample.class);
+                if (apiSuccessCodeExample != null) {
+                    generateResponseCodeExample(operation, apiSuccessCodeExample.value());
+                }
+            }
+            return operation;
+        };
+    }
+
+    private void generateResponseCodeExample(Operation operation,
+        ErrorType[] errorTypes) {
+        ApiResponses responses = operation.getResponses();
+        // ExampleHolder(에러 응답값) 객체를 만들고 에러 코드별로 그룹화
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorTypes)
+            .map(
+                errorType -> ExampleHolder.builder()
+                    .holder(getSwaggerExample(errorType))
+                    .code(errorType.getHttpStatusCode())
+                    .name(errorType.name())
+                    .build()
+            )
+            .collect(Collectors.groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private void generateResponseCodeExample(Operation operation,
+        ErrorType errorType) {
+        ApiResponses responses = operation.getResponses();
+        // ExampleHolder 객체 생성 및 ApiResponses에 추가
+
+        ExampleHolder exampleHolder = ExampleHolder.builder()
+            .holder(getSwaggerExample(errorType))
+            .name(errorType.name())
+            .code(errorType.getHttpStatusCode())
+            .build();
+
+        addExamplesToResponses(responses, exampleHolder);
+
+    }
+
+    private void addExamplesToResponses(ApiResponses responses, ExampleHolder exampleHolder) {
+        Content content = new Content();
+        MediaType mediaType = new MediaType();
+        ApiResponse apiResponse = new ApiResponse();
+
+        mediaType.addExamples(exampleHolder.getName(), exampleHolder.getHolder());
+        content.addMediaType("application/json", mediaType);
+        apiResponse.content(content);
+        responses.addApiResponse(String.valueOf(exampleHolder.getCode()), apiResponse);
+    }
+
+    private void addExamplesToResponses(ApiResponses responses,
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+
+        statusWithExampleHolders.forEach(
+            (status, v) -> {
+                Content content = new Content();
+                MediaType mediaType = new MediaType();
+                ApiResponse apiResponse = new ApiResponse();
+
+                v.forEach(
+                    exampleHolder -> mediaType.addExamples(
+                        exampleHolder.getName(),
+                        exampleHolder.getHolder()
+                    )
+                );
+                content.addMediaType("application/json", mediaType);
+                apiResponse.setContent(content);
+                responses.addApiResponse(String.valueOf(status), apiResponse);
+            }
+        );
+    }
+
+    private Example getSwaggerExample(ErrorType errorType) {
+        com.example.rentalSystem.global.response.ApiResponse<?> errorResponseDto = com.example.rentalSystem.global.response.ApiResponse.error(
+            errorType);
+        Example example = new Example();
+        example.setValue(errorResponseDto);
+
+        return example;
+    }
+
     private static Info apiInfo() {
         return new Info().title("명지대 시설 대여 API")
             .version("1.0")
@@ -51,6 +161,8 @@ public class SwaggerConfig {
         return GroupedOpenApi.builder()
             .group("전체")
             .pathsToMatch("/**")
+            .addOperationCustomizer(
+                customizer())
             .build();
     }
 

--- a/src/main/java/com/example/rentalSystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/rentalSystem/global/exception/GlobalExceptionHandler.java
@@ -17,28 +17,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleException(Exception e) {
         log.warn(e.getMessage(), e);
         return ApiResponse.error(ErrorType.BAD_REQUEST);
     }
 
     @ExceptionHandler(EntityNotFoundException.class)
-    @ResponseStatus(HttpStatus.NOT_FOUND)
     public ApiResponse<?> handleEntityNotFoundException(EntityNotFoundException e) {
         log.warn(e.getMessage(), e);
         return ApiResponse.error(ErrorType.ENTITY_NOT_FOUND, e.getMessage());
     }
 
     @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<ApiResponse<?>> handleBusinessException(CustomException e) {
+    protected ApiResponse<?> handleBusinessException(CustomException e) {
         log.error("CustomException", e);
-        ApiResponse<?> apiResponse = ApiResponse.error(e.getErrorType());
-        return ResponseEntity.status(e.getErrorType().getHttpStatusCode()).body(apiResponse);
+        return ApiResponse.error(e.getErrorType());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ApiResponse<?> handleValidationExceptions(MethodArgumentNotValidException ex) {
         String errorMessage = ex.getBindingResult()
             .getFieldErrors()

--- a/src/main/java/com/example/rentalSystem/global/response/example/ApiErrorCodeExample.java
+++ b/src/main/java/com/example/rentalSystem/global/response/example/ApiErrorCodeExample.java
@@ -1,0 +1,15 @@
+package com.example.rentalSystem.global.response.example;
+
+import com.example.rentalSystem.global.response.type.ErrorType;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExample {
+
+    ErrorType value();
+}

--- a/src/main/java/com/example/rentalSystem/global/response/example/ApiErrorCodeExamples.java
+++ b/src/main/java/com/example/rentalSystem/global/response/example/ApiErrorCodeExamples.java
@@ -1,0 +1,16 @@
+package com.example.rentalSystem.global.response.example;
+
+
+import com.example.rentalSystem.global.response.type.ErrorType;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+
+    ErrorType[] value();
+}

--- a/src/main/java/com/example/rentalSystem/global/response/example/ExampleHolder.java
+++ b/src/main/java/com/example/rentalSystem/global/response/example/ExampleHolder.java
@@ -1,0 +1,17 @@
+package com.example.rentalSystem.global.response.example;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+
+}


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

Swagger에서 예외 응답에 경우 @ApiResponse 대신 커스텀한 @ApiErrorCodeExample 도입
# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [0bd38b6fbe5bb3b830150770fba72a5566f4f3ea]
기존 @ApiResponse인 경우엔 매개변수로 code, message를 String 형태로 받아야 했다.
그럴 경우엔 ErrorType으로 지정한 값과 다르게 나타내게 수 있고, 변경되었을 경우에 수정도 매우 어려워 질 것으로 생각이 들었다.
그리고 무엇보다 프로덕션 코드가 너무 더러워보였다.
그렇기 때문에 @ApiErrorCodeExample을 통해 ErrorType을 주어서 예외 메시지를 반환하도록 하였다.

- [ ]

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 라이브러리 의존성 버전을 2.2.0에서 2.5.0으로 업데이트하여 성능과 안정성을 향상시켰습니다.
  
- **Documentation**
  - API 문서에 오류 코드 예시와 설명을 추가해, 오류 발생 시 보다 명확한 안내를 제공합니다.
  
- **Refactor**
  - 여러 API 엔드포인트에서 문서 인터페이스를 구현하여 응답 처리와 기본 페이지네이션 설정을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->