### PR TITLE
[Feat] 로그인한 멤버의 id(구별 값)과 이름 조회 API 구현

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.example.rentalSystem.domain.member.controller;
+
+import com.example.rentalSystem.domain.member.controller.dto.response.MemberInfoResponse;
+import com.example.rentalSystem.domain.member.entity.CustomerDetails;
+import com.example.rentalSystem.domain.member.service.MemberService;
+import com.example.rentalSystem.global.response.ApiResponse;
+import com.example.rentalSystem.global.response.type.SuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController implements MemberControllerDocs {
+
+    private final MemberService memberService;
+
+    @Override
+    @GetMapping
+    public ApiResponse<MemberInfoResponse> getMemberInfo(
+        @AuthenticationPrincipal CustomerDetails customerDetails
+    ) {
+        String email = customerDetails.getUsername();
+        return ApiResponse.success(SuccessType.SUCCESS, memberService.getMemberInfoByEmail(email));
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/controller/MemberControllerDocs.java
@@ -1,0 +1,12 @@
+package com.example.rentalSystem.domain.member.controller;
+
+import com.example.rentalSystem.domain.member.controller.dto.response.MemberInfoResponse;
+import com.example.rentalSystem.domain.member.entity.CustomerDetails;
+import com.example.rentalSystem.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "회원 정보 관련 API")
+public interface MemberControllerDocs {
+
+    ApiResponse<MemberInfoResponse> getMemberInfo(CustomerDetails customerDetails);
+}

--- a/src/main/java/com/example/rentalSystem/domain/member/controller/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/controller/dto/response/MemberInfoResponse.java
@@ -1,0 +1,11 @@
+package com.example.rentalSystem.domain.member.controller.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record MemberInfoResponse(
+    long id,
+    String name
+) {
+
+}

--- a/src/main/java/com/example/rentalSystem/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/rentalSystem/domain/member/service/MemberService.java
@@ -1,0 +1,25 @@
+package com.example.rentalSystem.domain.member.service;
+
+import com.example.rentalSystem.domain.member.controller.dto.response.MemberInfoResponse;
+import com.example.rentalSystem.domain.member.entity.Member;
+import com.example.rentalSystem.domain.member.repository.MemberRepository;
+import com.example.rentalSystem.global.exception.custom.CustomException;
+import com.example.rentalSystem.global.response.type.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberInfoResponse getMemberInfoByEmail(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(() -> new CustomException(
+            ErrorType.ENTITY_NOT_FOUND));
+        return MemberInfoResponse.builder()
+            .id(member.getId())
+            .name(member.getName())
+            .build();
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/professor/controller/dto/response/ProfessorDetailResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/professor/controller/dto/response/ProfessorDetailResponse.java
@@ -4,6 +4,7 @@ import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.professor.entity.Professor;
 
 public record ProfessorDetailResponse(
+    long id,
     String name,
     AffiliationType campus,
     AffiliationType college,
@@ -13,6 +14,7 @@ public record ProfessorDetailResponse(
 
     public static ProfessorDetailResponse from(Professor professor) {
         return new ProfessorDetailResponse(
+            professor.getId(),
             professor.getName(),
             professor.getCampusType(),
             professor.getCollege(),


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용
로그인시엔 토큰만 반환하도록 하고, 로그인한 사람의 정보는 토큰을 통해 그 사람에 대한 id와 이름을 반환하도록 추가했습니다.
또한 교수 정보 조회 응답에도 교수 id가 포함되도록 변경했습니다.

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [ ]
- [ ]

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호