### PR TITLE
[Feat] 대여 신청시, 대여에 대한 승인, 허가할 때 시설의 TimeTable의 시간 상태도 변경되도록 구현

### DIFF
--- a/src/main/generated/com/example/rentalSystem/domain/rentalhistory/entity/QRentalHistory.java
+++ b/src/main/generated/com/example/rentalSystem/domain/rentalhistory/entity/QRentalHistory.java
@@ -45,9 +45,9 @@ public class QRentalHistory extends EntityPathBase<RentalHistory> {
 
     public final EnumPath<RentalApplicationResult> rentalApplicationResult = createEnum("rentalApplicationResult", RentalApplicationResult.class);
 
-    public final DateTimePath<java.time.LocalDateTime> rentalEndDate = createDateTime("rentalEndDate", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> rentalEndDateTime = createDateTime("rentalEndDateTime", java.time.LocalDateTime.class);
 
-    public final DateTimePath<java.time.LocalDateTime> rentalStartDate = createDateTime("rentalStartDate", java.time.LocalDateTime.class);
+    public final DateTimePath<java.time.LocalDateTime> rentalStartDateTime = createDateTime("rentalStartDateTime", java.time.LocalDateTime.class);
 
     public final com.example.rentalSystem.domain.student.entity.QStudent student;
 

--- a/src/main/java/com/example/rentalSystem/domain/approval/controller/dto/request/RegisterRentalResultRequest.java
+++ b/src/main/java/com/example/rentalSystem/domain/approval/controller/dto/request/RegisterRentalResultRequest.java
@@ -4,7 +4,7 @@ import com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationRes
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RegisterRentalResultRequest(
-    @Schema(description = "대여 신청 결과", example = "PERMITTED,DENIED")
+    @Schema(description = "대여 신청 결과", example = "PIC or PROFESSOR + _ + PERMITTED or DENIED")
     RentalApplicationResult rentalApplicationResult,
     @Schema(description = "사유", example = "거절시에만 전달됩니다.")
     String reason

--- a/src/main/java/com/example/rentalSystem/domain/approval/entity/ProfessorApproval.java
+++ b/src/main/java/com/example/rentalSystem/domain/approval/entity/ProfessorApproval.java
@@ -1,6 +1,6 @@
 package com.example.rentalSystem.domain.approval.entity;
 
-import static com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult.DENIED;
+import static com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult.PROFESSOR_DENIED;
 
 import com.example.rentalSystem.domain.affiliation.type.AffiliationType;
 import com.example.rentalSystem.domain.approval.controller.dto.request.RegisterRentalResultRequest;
@@ -62,10 +62,10 @@ public class ProfessorApproval extends BaseTimeEntity {
 
     public void registerResult(RegisterRentalResultRequest registerRentalResultRequest) {
         this.rentalApplicationResult = registerRentalResultRequest.rentalApplicationResult();
-        if (this.rentalApplicationResult == DENIED) {
+        if (this.rentalApplicationResult == PROFESSOR_DENIED) {
+            rentalHistory.registerApplicationResult(rentalApplicationResult);
             this.reason = registerRentalResultRequest.reason();
         }
-
     }
 }
 

--- a/src/main/java/com/example/rentalSystem/domain/approval/service/ApprovalService.java
+++ b/src/main/java/com/example/rentalSystem/domain/approval/service/ApprovalService.java
@@ -9,6 +9,7 @@ import com.example.rentalSystem.domain.facility.controller.dto.response.Facility
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.pic.entity.Pic;
 import com.example.rentalSystem.domain.rentalhistory.controller.dto.response.RentalInfoResponse;
+import com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult;
 import com.example.rentalSystem.domain.rentalhistory.entity.RentalHistory;
 import com.example.rentalSystem.domain.rentalhistory.implement.FacilityScheduleManager;
 import com.example.rentalSystem.domain.rentalhistory.implement.RentalHistoryImpl;
@@ -37,14 +38,8 @@ public class ApprovalService {
         ProfessorApproval professorApproval = professorApprovalImpl.findById(professorApprovalId);
         professorApproval.registerResult(registerRentalResultRequest);
 
-        Facility facility = professorApproval.getRentalHistory().getFacility();
         RentalHistory rentalHistory = professorApproval.getRentalHistory();
-
-        LocalDateTime rentalStartDateTime = rentalHistory.getRentalStartDateTime();
-        LocalDateTime rentalEndDateTime = rentalHistory.getRentalEndDateTime();
-
-        facilityScheduleManager.updateTimeStatus(facility, rentalStartDateTime,
-            rentalEndDateTime,
+        updateFacilityTimeStatus(rentalHistory,
             registerRentalResultRequest.rentalApplicationResult());
     }
 
@@ -70,6 +65,19 @@ public class ApprovalService {
 
     }
 
+    public void registerRentalResultByPic(
+        Long rentalHistoryId,
+        Pic pic,
+        RegisterRentalResultRequest registerRentalResultRequest
+    ) {
+        RentalHistory rentalHistory = rentalHistoryImpl.findById(rentalHistoryId);
+        rentalHistory.registerApplicationResult(pic, registerRentalResultRequest);
+
+        updateFacilityTimeStatus(rentalHistory,
+            registerRentalResultRequest.rentalApplicationResult());
+    }
+
+
     private RentalInfoResponse createRentalInfo(
         RentalHistory rentalHistory
     ) {
@@ -86,21 +94,21 @@ public class ApprovalService {
         );
     }
 
-    public void registerRentalResultByPic(
-        Long rentalHistoryId,
-        Pic pic,
-        RegisterRentalResultRequest registerRentalResultRequest
+
+    private void updateFacilityTimeStatus(
+        RentalHistory rentalHistory,
+        RentalApplicationResult result
     ) {
-        RentalHistory rentalHistory = rentalHistoryImpl.findById(rentalHistoryId);
-        rentalHistory.registerApplicationResult(pic, registerRentalResultRequest);
-
         Facility facility = rentalHistory.getFacility();
-
         LocalDateTime rentalStartDateTime = rentalHistory.getRentalStartDateTime();
         LocalDateTime rentalEndDateTime = rentalHistory.getRentalEndDateTime();
 
-        facilityScheduleManager.updateTimeStatus(facility, rentalStartDateTime,
+        facilityScheduleManager.updateTimeStatus(
+            facility,
+            rentalStartDateTime,
             rentalEndDateTime,
-            registerRentalResultRequest.rentalApplicationResult());
+            result
+        );
     }
+
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/entity/timeTable/TimeStatus.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/entity/timeTable/TimeStatus.java
@@ -7,7 +7,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum TimeStatus {
-    AVAILABLE("예약가능"), UNAVAILABLE("이용불가"), RESERVED("예약완료"), WAITING("예약대기"), CURRENT("현재예약");
+    AVAILABLE("예약가능"),
+    UNAVAILABLE("이용불가"),
+    RESERVED("예약완료"),
+    WAITING("예약대기"),
+    CURRENT("현재예약");
     final String description;
 
 }

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/dto/request/CreateRentalRequest.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/dto/request/CreateRentalRequest.java
@@ -15,9 +15,9 @@ public record CreateRentalRequest(
     @Schema(example = "1")
     String facilityId,
     @Schema(description = "대여 시작 시간", example = "YYYY-MM-DDTHH:MM:SS")
-    LocalDateTime startTime,
+    LocalDateTime startDateTime,
     @Schema(description = "대역 종료 시간", example = "YYYY-MM-DDTHH:MM:SS")
-    LocalDateTime endTime,
+    LocalDateTime endDateTime,
     @Schema(description = "조직명", example = "COW")
     String organization,
     @Schema(description = "사용자 수", example = "4")
@@ -32,8 +32,8 @@ public record CreateRentalRequest(
         return RentalHistory.builder()
             .purpose(this.purpose)
             .organization(this.organization)
-            .rentalStartDate(startTime)
-            .rentalEndDate(endTime)
+            .rentalStartDateTime(startDateTime)
+            .rentalEndDateTime(endDateTime)
             .rentalApplicationResult(RentalApplicationResult.WAITING)
             .student(student)
             .facility(facility)

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/dto/response/RentalHistoryResponseDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/controller/dto/response/RentalHistoryResponseDto.java
@@ -51,8 +51,8 @@ public class RentalHistoryResponseDto {
                 FacilityResponse.fromRentalHistory(rentalHistory))
             .professorApprovalResponse(
                 ProfessorApprovalResponse.from(professorApproval))
-            .startTime(rentalHistory.getRentalStartDate())
-            .endTime(rentalHistory.getRentalEndDate())
+            .startTime(rentalHistory.getRentalStartDateTime())
+            .endTime(rentalHistory.getRentalEndDateTime())
             .organization(rentalHistory.getOrganization())
             .purpose(rentalHistory.getPurpose())
             .createAt(rentalHistory.getCreated_at())

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalApplicationResult.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalApplicationResult.java
@@ -7,9 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum RentalApplicationResult {
 
-    PERMITTED("허가 완료"),
+    PIC_PERMITTED("교직원 승인 허가"),
+    PROFESSOR_PERMITTED("교수 승인 허가"),
     WAITING("대기중"),
-    DENIED("거절됨");
+    PIC_DENIED("교직원 승인 거절"),
+    PROFESSOR_DENIED("교수 승인 거절");
 
     private final String description;
 }

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
@@ -1,6 +1,7 @@
 package com.example.rentalSystem.domain.rentalhistory.entity;
 
-import static com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult.DENIED;
+import static com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult.PIC_DENIED;
+import static com.example.rentalSystem.domain.rentalhistory.entity.RentalApplicationResult.PROFESSOR_DENIED;
 
 import com.example.rentalSystem.domain.approval.controller.dto.request.RegisterRentalResultRequest;
 import com.example.rentalSystem.domain.common.BaseTimeEntity;
@@ -39,10 +40,10 @@ public class RentalHistory extends BaseTimeEntity {
     private String organization;
 
     @Column(nullable = false)
-    private LocalDateTime rentalStartDate;
+    private LocalDateTime rentalStartDateTime;
 
     @Column(nullable = false)
-    private LocalDateTime rentalEndDate;
+    private LocalDateTime rentalEndDateTime;
 
     @Column
     @Enumerated(EnumType.STRING)
@@ -70,8 +71,8 @@ public class RentalHistory extends BaseTimeEntity {
     public RentalHistory(
         String purpose,
         String organization,
-        LocalDateTime rentalStartDate,
-        LocalDateTime rentalEndDate,
+        LocalDateTime rentalStartDateTime,
+        LocalDateTime rentalEndDateTime,
         RentalApplicationResult rentalApplicationResult,
         Student student,
         int numberOfPeople,
@@ -79,15 +80,15 @@ public class RentalHistory extends BaseTimeEntity {
     ) {
         this.purpose = purpose;
         this.organization = organization;
-        this.rentalStartDate = rentalStartDate;
-        this.rentalEndDate = rentalEndDate;
+        this.rentalStartDateTime = rentalStartDateTime;
+        this.rentalEndDateTime = rentalEndDateTime;
         this.rentalApplicationResult = rentalApplicationResult;
         this.student = student;
         this.facility = facility;
         this.numberOfPeople = numberOfPeople;
     }
 
-    public void defineApplicationResult(
+    public void registerApplicationResult(
         Pic pic,
         RegisterRentalResultRequest registerRentalResultRequest
     ) {
@@ -95,8 +96,20 @@ public class RentalHistory extends BaseTimeEntity {
         this.rentalApplicationResult = registerRentalResultRequest.rentalApplicationResult();
         this.defineDateTime = LocalDateTime.now();
 
-        if (this.rentalApplicationResult == DENIED) {
+        if (this.rentalApplicationResult == PIC_DENIED) {
             this.reason = registerRentalResultRequest.reason();
+        }
+    }
+
+    public void registerApplicationResult(
+        RentalApplicationResult rentalApplicationResult
+    ) {
+
+        this.rentalApplicationResult = rentalApplicationResult;
+        this.defineDateTime = LocalDateTime.now();
+
+        if (this.rentalApplicationResult == PROFESSOR_DENIED) {
+            this.reason = "교수님의 승인 거절";
         }
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/entity/RentalHistory.java
@@ -93,9 +93,7 @@ public class RentalHistory extends BaseTimeEntity {
         RegisterRentalResultRequest registerRentalResultRequest
     ) {
         this.pic = pic;
-        this.rentalApplicationResult = registerRentalResultRequest.rentalApplicationResult();
-        this.defineDateTime = LocalDateTime.now();
-
+        setApplicationResult(registerRentalResultRequest.rentalApplicationResult());
         if (this.rentalApplicationResult == PIC_DENIED) {
             this.reason = registerRentalResultRequest.reason();
         }
@@ -105,11 +103,14 @@ public class RentalHistory extends BaseTimeEntity {
         RentalApplicationResult rentalApplicationResult
     ) {
 
-        this.rentalApplicationResult = rentalApplicationResult;
-        this.defineDateTime = LocalDateTime.now();
-
+        setApplicationResult(rentalApplicationResult);
         if (this.rentalApplicationResult == PROFESSOR_DENIED) {
             this.reason = "교수님의 승인 거절";
         }
+    }
+
+    private void setApplicationResult(RentalApplicationResult rentalApplicationResult) {
+        this.rentalApplicationResult = rentalApplicationResult;
+        this.defineDateTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/rentalhistory/implement/FacilityScheduleManager.java
+++ b/src/main/java/com/example/rentalSystem/domain/rentalhistory/implement/FacilityScheduleManager.java
@@ -78,7 +78,10 @@ public class FacilityScheduleManager {
                 updateTimeSlotStatus(timeTable.getTimeSlot(), startTime, endTime, CURRENT);
             case PIC_PERMITTED ->
                 updateTimeSlotStatus(timeTable.getTimeSlot(), startTime, endTime, RESERVED);
-            default -> updateTimeSlotStatus(timeTable.getTimeSlot(), startTime, endTime, AVAILABLE);
+            case PIC_DENIED, PROFESSOR_DENIED ->
+                updateTimeSlotStatus(timeTable.getTimeSlot(), startTime, endTime, AVAILABLE);
+            case WAITING ->
+                updateTimeSlotStatus(timeTable.getTimeSlot(), startTime, endTime, WAITING);
         }
     }
 

--- a/src/main/java/com/example/rentalSystem/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/rentalSystem/global/config/SwaggerConfig.java
@@ -1,7 +1,5 @@
 package com.example.rentalSystem.global.config;
 
-import static java.rmi.server.LogStream.log;
-
 import com.example.rentalSystem.global.response.example.ApiErrorCodeExample;
 import com.example.rentalSystem.global.response.example.ApiErrorCodeExamples;
 import com.example.rentalSystem.global.response.example.ExampleHolder;

--- a/src/main/resources/professor.csv
+++ b/src/main/resources/professor.csv
@@ -1,2 +1,2 @@
 id,name,campusType,college,major,email
-1,최성운,서울,ICT융합대학,응용소프트웨어전공,gkstkddbs99@naver.com
+1,최성운,서울,ICT융합대학,응용소프트웨어전공,rlaguswl221@naver.com


### PR DESCRIPTION
# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

대여에 대한 상태값인 Application과 시설의 시간표가 가지는 시설의 특정 시간대에 대여할 수 있는 지 없는 지를 나타내는 상태끼리의 동기화를 이루도록 로직을 구현헀습니다.

구조나 로직적으로 마음에 들지 않아 리팩토링이 필요하다고 생각합니다.


<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [ ]
- [ ]

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #이슈번호

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 대여 신청 결과에 따라 시설 예약 상태가 자동 갱신되어, 예약 정보가 보다 정확하게 표시됩니다.
	- 대여 요청 및 내역에 날짜와 시간이 통합되어, 예약 관련 정보가 명확하게 제공됩니다.

- **리팩토링**
	- 승인 결과 명칭이 구체적으로 수정되어, 교수와 직원의 상태가 보다 명확하게 구분됩니다.
	- 예약 처리 프로세스의 개선으로 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->