### PR TITLE
feat: 시설 별 현재 이용중인 단체 조회하기 API 구현

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalController.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalController.java
@@ -65,9 +65,10 @@ public class RentalController implements RentalControllerDocs {
     @Override
     @GetMapping("/facilities/{facilityId}/in-use")
     public ApiResponse<List<CurrentInUseGroupResponse>> getCurrentInUseByFacility(
-            @PathVariable(name = "facilityId") Long facilityId
+            @PathVariable Long facilityId
     ) {
-        List<CurrentInUseGroupResponse> result = rentalService.getCurrentInUseByFacility(facilityId);
-        return ApiResponse.success(SuccessType.SUCCESS, result); // 빈 배열이면 프런트에서 섹션 숨김
+        List<CurrentInUseGroupResponse> result =
+                rentalService.getCurrentInUseByFacility(facilityId);
+        return ApiResponse.success(SuccessType.SUCCESS, result);
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalController.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalController.java
@@ -1,24 +1,21 @@
 package com.example.rentalSystem.domain.book.rentalhistory.controller;
 
 import com.example.rentalSystem.domain.book.rentalhistory.dto.request.CreateRentalRequest;
+import com.example.rentalSystem.domain.book.rentalhistory.dto.response.CurrentInUseGroupResponse;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.response.RentalHistoryDetailResponseDto;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.response.RentalHistoryResponseDto;
 import com.example.rentalSystem.domain.book.rentalhistory.service.RentalService;
 import com.example.rentalSystem.global.auth.security.CustomerDetails;
 import com.example.rentalSystem.global.response.ApiResponse;
 import com.example.rentalSystem.global.response.type.SuccessType;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,8 +27,8 @@ public class RentalController implements RentalControllerDocs {
     @Override
     @PostMapping()
     public ApiResponse<?> createRental(
-        @AuthenticationPrincipal CustomerDetails customerDetails,
-        @RequestBody CreateRentalRequest createRentalRequest) {
+            @AuthenticationPrincipal CustomerDetails customerDetails,
+            @RequestBody CreateRentalRequest createRentalRequest) {
         rentalService.create(customerDetails.getStudent(), createRentalRequest);
         return ApiResponse.success(SuccessType.CREATED);
     }
@@ -39,9 +36,9 @@ public class RentalController implements RentalControllerDocs {
     @Override
     @GetMapping()
     public ApiResponse<Page<RentalHistoryResponseDto>> getAllRentalHistory(
-        @PageableDefault Pageable pageable) {
+            @PageableDefault Pageable pageable) {
         Page<RentalHistoryResponseDto> rentalHistoryResponseDtoList = rentalService.getAllRentalHistory(
-            pageable);
+                pageable);
 
         return ApiResponse.success(SuccessType.SUCCESS, rentalHistoryResponseDtoList);
     }
@@ -49,19 +46,28 @@ public class RentalController implements RentalControllerDocs {
     @Override
     @GetMapping("/students/{studentId}")
     public ApiResponse<?> getAllRentalHistoryByStudent(
-        @PathVariable(name = "studentId") String studentId) {
+            @PathVariable(name = "studentId") String studentId) {
         List<RentalHistoryResponseDto> rentalHistoryResponseDtoList = rentalService.getAllRentalHistoryByStudentId(
-            studentId);
+                studentId);
         return ApiResponse.success(SuccessType.SUCCESS, rentalHistoryResponseDtoList);
     }
 
     @Override
     @GetMapping("/{rentalHistoryId}")
     public ApiResponse<?> getRentalHistoryDetail(
-        @PathVariable(name = "rentalHistoryId") Long rentalHistoryId
+            @PathVariable(name = "rentalHistoryId") Long rentalHistoryId
     ) {
         RentalHistoryDetailResponseDto rentalHistoryDetailResponseDto = rentalService.getRentalHistoryDetailById(
-            rentalHistoryId);
+                rentalHistoryId);
         return ApiResponse.success(SuccessType.SUCCESS, rentalHistoryDetailResponseDto);
+    }
+
+    @Override
+    @GetMapping("/facilities/{facilityId}/in-use")
+    public ApiResponse<List<CurrentInUseGroupResponse>> getCurrentInUseByFacility(
+            @PathVariable(name = "facilityId") Long facilityId
+    ) {
+        List<CurrentInUseGroupResponse> result = rentalService.getCurrentInUseByFacility(facilityId);
+        return ApiResponse.success(SuccessType.SUCCESS, result); // 빈 배열이면 프런트에서 섹션 숨김
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalControllerDocs.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -49,7 +48,5 @@ public interface RentalControllerDocs {
 
 
     @Operation(summary = "특정 시설의 현재 이용 중인 단체 조회")
-    ApiResponse<List<CurrentInUseGroupResponse>> getCurrentInUseByFacility(
-            @PathVariable(name = "facilityId") Long facilityId
-    );
+    ApiResponse<List<CurrentInUseGroupResponse>> getCurrentInUseByFacility(Long facilityId);
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalControllerDocs.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/controller/RentalControllerDocs.java
@@ -1,10 +1,7 @@
 package com.example.rentalSystem.domain.book.rentalhistory.controller;
 
-import static com.example.rentalSystem.global.response.type.ErrorType.ENTITY_NOT_FOUND;
-import static com.example.rentalSystem.global.response.type.ErrorType.FAIL_RENTAL_REQUEST;
-import static com.example.rentalSystem.global.response.type.ErrorType.FAIL_SEND_EMAIL;
-
 import com.example.rentalSystem.domain.book.rentalhistory.dto.request.CreateRentalRequest;
+import com.example.rentalSystem.domain.book.rentalhistory.dto.response.CurrentInUseGroupResponse;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.response.RentalHistoryResponseDto;
 import com.example.rentalSystem.global.auth.security.CustomerDetails;
 import com.example.rentalSystem.global.response.ApiResponse;
@@ -15,33 +12,44 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+import static com.example.rentalSystem.global.response.type.ErrorType.*;
 
 @Tag(name = "시설 대여에 관한 API", description = "시설 대여, 전체 대여 내역 조회, 시설 대여 내역 상세 조회, 학생 시설 대여 내역 조회")
 public interface RentalControllerDocs {
 
     @Operation(summary = "시설 대여 신청")
     @ApiErrorCodeExamples(
-        {FAIL_RENTAL_REQUEST, ENTITY_NOT_FOUND, FAIL_SEND_EMAIL}
+            {FAIL_RENTAL_REQUEST, ENTITY_NOT_FOUND, FAIL_SEND_EMAIL}
     )
     ApiResponse<?> createRental(
-        CustomerDetails customerDetails,
-        CreateRentalRequest createRentalRequest);
+            CustomerDetails customerDetails,
+            CreateRentalRequest createRentalRequest);
 
     @Operation(summary = "시설 대여 내역 전체 조회")
     ApiResponse<Page<RentalHistoryResponseDto>> getAllRentalHistory(
-        @Parameter(example = "{\n"
-            + "  \"page\": 0,\n"
-            + "  \"size\": 10\n"
-            + "}")
-        Pageable pageable);
+            @Parameter(example = "{\n"
+                    + "  \"page\": 0,\n"
+                    + "  \"size\": 10\n"
+                    + "}")
+            Pageable pageable);
 
     @Operation(summary = "학생 시설 대여 내역 전체 조회")
     ApiResponse<?> getAllRentalHistoryByStudent(
-        String studentId);
+            String studentId);
 
     @Operation(summary = "시설 대여 내역 상세 조회")
     @ApiErrorCodeExample(ENTITY_NOT_FOUND)
     ApiResponse<?> getRentalHistoryDetail(
-        Long rentalHistoryId
+            Long rentalHistoryId
+    );
+
+
+    @Operation(summary = "특정 시설의 현재 이용 중인 단체 조회")
+    ApiResponse<List<CurrentInUseGroupResponse>> getCurrentInUseByFacility(
+            @PathVariable(name = "facilityId") Long facilityId
     );
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/dto/response/CurrentInUseGroupResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/dto/response/CurrentInUseGroupResponse.java
@@ -1,0 +1,25 @@
+package com.example.rentalSystem.domain.book.rentalhistory.dto.response;
+
+import com.example.rentalSystem.domain.book.rentalhistory.entity.RentalHistory;
+
+import java.time.LocalDateTime;
+
+public record CurrentInUseGroupResponse(
+        Long rentalHistoryId,
+        String organization,
+        String purpose,
+        int numberOfPeople,
+        LocalDateTime startTime,
+        LocalDateTime endTime
+) {
+    public static CurrentInUseGroupResponse from(RentalHistory r) {
+        return new CurrentInUseGroupResponse(
+                r.getId(),
+                r.getOrganization(),
+                r.getPurpose(),
+                r.getNumberOfPeople(),
+                r.getStartDateTime(),
+                r.getEndDateTime()
+        );
+    }
+}

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/dto/response/CurrentInUseGroupResponse.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/dto/response/CurrentInUseGroupResponse.java
@@ -1,6 +1,7 @@
 package com.example.rentalSystem.domain.book.rentalhistory.dto.response;
 
 import com.example.rentalSystem.domain.book.rentalhistory.entity.RentalHistory;
+import com.example.rentalSystem.domain.member.student.dto.response.StudentInfoResponse;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +11,8 @@ public record CurrentInUseGroupResponse(
         String purpose,
         int numberOfPeople,
         LocalDateTime startTime,
-        LocalDateTime endTime
+        LocalDateTime endTime,
+        StudentInfoResponse applicant
 ) {
     public static CurrentInUseGroupResponse from(RentalHistory r) {
         return new CurrentInUseGroupResponse(
@@ -19,7 +21,8 @@ public record CurrentInUseGroupResponse(
                 r.getPurpose(),
                 r.getNumberOfPeople(),
                 r.getStartDateTime(),
-                r.getEndDateTime()
+                r.getEndDateTime(),
+                StudentInfoResponse.toStudentInfoResponse(r.getStudent())
         );
     }
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/entity/RentalHistory.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/entity/RentalHistory.java
@@ -6,23 +6,12 @@ import com.example.rentalSystem.domain.common.BaseTimeEntity;
 import com.example.rentalSystem.domain.facility.entity.Facility;
 import com.example.rentalSystem.domain.member.pic.entity.Pic;
 import com.example.rentalSystem.domain.member.student.entity.Student;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -77,8 +66,8 @@ public class RentalHistory extends BaseTimeEntity {
     private String reason;
 
     public void registerApplicationResult(
-        Pic pic,
-        RegisterRentalResultRequest registerRentalResultRequest
+            Pic pic,
+            RegisterRentalResultRequest registerRentalResultRequest
     ) {
         this.pic = pic;
         setApplicationResult(registerRentalResultRequest.rentalApplicationResult());
@@ -88,7 +77,7 @@ public class RentalHistory extends BaseTimeEntity {
     }
 
     public void registerApplicationResult(
-        RentalApplicationResult rentalApplicationResult
+            RentalApplicationResult rentalApplicationResult
     ) {
 
         setApplicationResult(rentalApplicationResult);

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/implement/RentalHistoryImpl.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/implement/RentalHistoryImpl.java
@@ -41,8 +41,9 @@ public class RentalHistoryImpl {
             Long facilityId, LocalDate startDate,
             LocalTime startTime, LocalTime endTime
     ) {
-        return rentalHistoryRepository.findByFacilityIdAndDateAndBetweenTime(facilityId, startDate,
-                startTime, endTime);
+        return rentalHistoryRepository.findByFacilityIdAndDateAndBetweenTime(
+                facilityId, startDate, startTime, endTime
+        );
     }
 
     public List<RentalHistory> getByFacilityIdAndDate(Long facilityId, LocalDate localDate) {
@@ -55,4 +56,3 @@ public class RentalHistoryImpl {
         );
     }
 }
-

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/implement/RentalHistoryImpl.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/implement/RentalHistoryImpl.java
@@ -1,16 +1,18 @@
 package com.example.rentalSystem.domain.book.rentalhistory.implement;
 
 import com.example.rentalSystem.domain.book.rentalhistory.entity.RentalHistory;
+import com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult;
 import com.example.rentalSystem.domain.book.rentalhistory.repository.RentalHistoryRepository;
 import com.example.rentalSystem.domain.member.student.entity.Student;
 import jakarta.persistence.EntityNotFoundException;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -20,7 +22,7 @@ public class RentalHistoryImpl {
 
     public RentalHistory findById(Long id) {
         return rentalHistoryRepository.findById(id)
-            .orElseThrow(EntityNotFoundException::new);
+                .orElseThrow(EntityNotFoundException::new);
     }
 
     public RentalHistory save(RentalHistory rentalHistory) {
@@ -36,15 +38,21 @@ public class RentalHistoryImpl {
     }
 
     public List<RentalHistory> getByFacilityIdAndDateAndBetweenTime(
-        Long facilityId, LocalDate startDate,
-        LocalTime startTime, LocalTime endTime
+            Long facilityId, LocalDate startDate,
+            LocalTime startTime, LocalTime endTime
     ) {
         return rentalHistoryRepository.findByFacilityIdAndDateAndBetweenTime(facilityId, startDate,
-            startTime, endTime);
+                startTime, endTime);
     }
 
     public List<RentalHistory> getByFacilityIdAndDate(Long facilityId, LocalDate localDate) {
         return rentalHistoryRepository.findByFacilityIdAndDate(facilityId, localDate);
+    }
+
+    public List<RentalHistory> findCurrentlyInUseByFacility(Long facilityId, LocalDate today, LocalTime nowTime) {
+        return rentalHistoryRepository.findCurrentlyInUseByFacility(
+                facilityId, today, nowTime, RentalApplicationResult.PIC_PERMITTED
+        );
     }
 }
 

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/repository/RentalHistoryRepository.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/repository/RentalHistoryRepository.java
@@ -1,14 +1,16 @@
 package com.example.rentalSystem.domain.book.rentalhistory.repository;
 
 import com.example.rentalSystem.domain.book.rentalhistory.entity.RentalHistory;
+import com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult;
 import com.example.rentalSystem.domain.member.student.entity.Student;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 @Repository
 public interface RentalHistoryRepository extends JpaRepository<RentalHistory, Long> {
@@ -16,17 +18,33 @@ public interface RentalHistoryRepository extends JpaRepository<RentalHistory, Lo
     List<RentalHistory> findAllByStudent(Student student);
 
     @Query("SELECT r FROM RentalHistory r " + "WHERE r.facility.id = :facilityId "
-        + "AND r.rentalStartDate  = :startDate "
-        + "AND r.rentalEndTime >= :startTime AND r.rentalStartTime <= :endTime")
+            + "AND r.rentalStartDate  = :startDate "
+            + "AND r.rentalEndTime >= :startTime AND r.rentalStartTime <= :endTime")
     List<RentalHistory> findByFacilityIdAndDateAndBetweenTime(
-        @Param("facilityId") Long facilityId,
-        @Param("startDate") LocalDate startDate,
-        @Param("startTime") LocalTime startTime,
-        @Param("endTime") LocalTime endTime);
+            @Param("facilityId") Long facilityId,
+            @Param("startDate") LocalDate startDate,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime);
 
     @Query("SELECT rh FROM RentalHistory rh " + "WHERE rh.facility.id = :facilityId "
-        + "AND rh.rentalStartDate <= :localDate AND rh.rentalEndDate >= :localDate")
+            + "AND rh.rentalStartDate <= :localDate AND rh.rentalEndDate >= :localDate")
     List<RentalHistory> findByFacilityIdAndDate(
-        @Param("facilityId") Long facilityId,
-        @Param("localDate") LocalDate localDate);
+            @Param("facilityId") Long facilityId,
+            @Param("localDate") LocalDate localDate);
+
+    @Query("""
+                SELECT r
+                FROM RentalHistory r
+                WHERE r.facility.id = :facilityId
+                  AND (r.rentalStartDate < :today OR (r.rentalStartDate = :today AND r.rentalStartTime <= :nowTime))
+                  AND (r.rentalEndDate   > :today OR (r.rentalEndDate   = :today AND r.rentalEndTime   >= :nowTime))
+                  AND r.rentalApplicationResult = :status
+                ORDER BY r.rentalStartDate, r.rentalStartTime
+            """)
+    List<RentalHistory> findCurrentlyInUseByFacility(
+            @Param("facilityId") Long facilityId,
+            @Param("today") LocalDate today,
+            @Param("nowTime") LocalTime nowTime,
+            @Param("status") RentalApplicationResult status
+    );
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/repository/RentalHistoryRepository.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/repository/RentalHistoryRepository.java
@@ -35,6 +35,7 @@ public interface RentalHistoryRepository extends JpaRepository<RentalHistory, Lo
     @Query("""
                 SELECT r
                 FROM RentalHistory r
+                JOIN FETCH r.student s
                 WHERE r.facility.id = :facilityId
                   AND (r.rentalStartDate < :today OR (r.rentalStartDate = :today AND r.rentalStartTime <= :nowTime))
                   AND (r.rentalEndDate   > :today OR (r.rentalEndDate   = :today AND r.rentalEndTime   >= :nowTime))

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/service/RentalService.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/service/RentalService.java
@@ -99,9 +99,12 @@ public class RentalService {
         LocalDate today = LocalDate.now(ZONE_SEOUL);
         LocalTime nowTime = LocalTime.now(ZONE_SEOUL);
 
-        List<RentalHistory> inUse = rentalHistoryImpl.findCurrentlyInUseByFacility(facilityId, today, nowTime);
-        return inUse.stream().map(CurrentInUseGroupResponse::from).toList();
+        List<RentalHistory> inUse = rentalHistoryImpl.findCurrentlyInUseByFacility(
+                facilityId, today, nowTime
+        );
+        return inUse.stream()
+                .map(CurrentInUseGroupResponse::from)
+                .toList();
     }
-
 
 }

--- a/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/service/RentalService.java
+++ b/src/main/java/com/example/rentalSystem/domain/book/rentalhistory/service/RentalService.java
@@ -1,11 +1,9 @@
 package com.example.rentalSystem.domain.book.rentalhistory.service;
 
-import static com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult.PROFESSOR_DENIED;
-import static com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult.WAITING;
-
 import com.example.rentalSystem.domain.book.approval.entity.ProfessorApproval;
 import com.example.rentalSystem.domain.book.approval.implement.ProfessorApprovalImpl;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.request.CreateRentalRequest;
+import com.example.rentalSystem.domain.book.rentalhistory.dto.response.CurrentInUseGroupResponse;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.response.RentalHistoryDetailResponseDto;
 import com.example.rentalSystem.domain.book.rentalhistory.dto.response.RentalHistoryResponseDto;
 import com.example.rentalSystem.domain.book.rentalhistory.entity.RentalHistory;
@@ -18,12 +16,19 @@ import com.example.rentalSystem.domain.member.professor.entity.Professor;
 import com.example.rentalSystem.domain.member.professor.implement.ProfessorManager;
 import com.example.rentalSystem.domain.member.student.entity.Student;
 import com.example.rentalSystem.domain.member.student.implement.StudentImpl;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult.PROFESSOR_DENIED;
+import static com.example.rentalSystem.domain.book.rentalhistory.entity.type.RentalApplicationResult.WAITING;
 
 @Service
 @Transactional(readOnly = true)
@@ -37,23 +42,24 @@ public class RentalService {
     private final ProfessorApprovalImpl professorApprovalImpl;
     private final FacilityScheduleManager facilityScheduleManager;
     private final EmailService emailService;
+    private static final ZoneId ZONE_SEOUL = ZoneId.of("Asia/Seoul");
 
     @Transactional
     public void create(Student student, CreateRentalRequest createRentalRequest) {
         Facility facility = facilityImpl.findById(
-            Long.parseLong(createRentalRequest.facilityId()));
+                Long.parseLong(createRentalRequest.facilityId()));
 
         facilityScheduleManager.checkAvailabilityAndReserve(
-            facility,
-            createRentalRequest.startDateTime(),
-            createRentalRequest.endDateTime()
+                facility,
+                createRentalRequest.startDateTime(),
+                createRentalRequest.endDateTime()
         );
 
         Professor professor = professorManager.findById(createRentalRequest.professorId());
         RentalHistory rentalHistory = createRentalRequest.toEntity(student, facility);
 
         ProfessorApproval professorApproval = createRentalRequest.toEntity(rentalHistory,
-            professor);
+                professor);
 
         rentalHistoryImpl.save(rentalHistory);
         professorApprovalImpl.save(professorApproval);
@@ -69,23 +75,33 @@ public class RentalService {
         Student student = studentImpl.findById(studentId);
         List<RentalHistory> rentalHistories = rentalHistoryImpl.findAllByStudent(student);
         return rentalHistories.stream()
-            .map(RentalHistoryResponseDto::from)
-            .toList();
+                .map(RentalHistoryResponseDto::from)
+                .toList();
     }
 
     public RentalHistoryDetailResponseDto getRentalHistoryDetailById(Long rentalHistoryId) {
         RentalHistory rentalHistory = rentalHistoryImpl.findById(rentalHistoryId);
         ProfessorApproval professorApproval = professorApprovalImpl.findByRentalHistory(
-            rentalHistory);
+                rentalHistory);
         Student student = rentalHistory.getStudent();
 
         if (
-            rentalHistory.getRentalApplicationResult() == WAITING ||
-                rentalHistory.getRentalApplicationResult() == PROFESSOR_DENIED
+                rentalHistory.getRentalApplicationResult() == WAITING ||
+                        rentalHistory.getRentalApplicationResult() == PROFESSOR_DENIED
         ) {
             return RentalHistoryDetailResponseDto.of(rentalHistory, professorApproval, student);
         }
         return RentalHistoryDetailResponseDto.of(rentalHistory, professorApproval, student,
-            rentalHistory.getPic());
+                rentalHistory.getPic());
     }
+
+    public List<CurrentInUseGroupResponse> getCurrentInUseByFacility(Long facilityId) {
+        LocalDate today = LocalDate.now(ZONE_SEOUL);
+        LocalTime nowTime = LocalTime.now(ZONE_SEOUL);
+
+        List<RentalHistory> inUse = rentalHistoryImpl.findCurrentlyInUseByFacility(facilityId, today, nowTime);
+        return inUse.stream().map(CurrentInUseGroupResponse::from).toList();
+    }
+
+
 }


### PR DESCRIPTION
# 요약
시설 상세 화면에서 현재 이용 중인 단체를 조회하는 API를 추가했습니다.

# 작업 내용
- `GET /rental/facilities/{facilityId}/in-use` 엔드포인트 추가
  - 특정 시설의 현재 이용 중인 단체 목록 조회
  - 조건: 현재 시간이 시작~종료 범위 안 && `applicationResult = PIC_PERMITTED`
- 테스트를 위해 DB 데이터 업데이트하여 정상 동작 확인

# 기타 (논의하고 싶은 부분)
- rental history 패키지에 API를 구현했는데, 적절한 패키지인지 좀 더 고민해봐야 할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 시설별 현재 사용 중인 그룹을 조회하는 API 엔드포인트 추가. 프런트에서 시설 상세 화면에 현재 사용 현황을 표시할 수 있습니다.
  - 대여 신청 처리 후 확인 메일이 자동 발송되도록 개선되어 알림 경험이 향상되었습니다.

- 문서
  - 신규 엔드포인트에 대한 API 문서가 추가되어 연동 가이드가 보완되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->