### PR TITLE
feat(global): Excel 처리 및 임포트 공용 모듈 추가

### DIFF
--- a/src/main/java/com/example/rentalSystem/global/excel/ErrorCollector.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/ErrorCollector.java
@@ -1,0 +1,43 @@
+package com.example.rentalSystem.global.excel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public class ErrorCollector {
+
+  public static final class Entry {
+
+    public final int rowIndex;
+    public final String field;
+    public final String message;
+    public final String rawValue;
+    public final Integer columnIndex;
+
+    public Entry(int rowIndex, String field, String message, String rawValue, Integer columnIndex) {
+      this.rowIndex = rowIndex;
+      this.field = field;
+      this.message = message;
+      this.rawValue = rawValue;
+      this.columnIndex = columnIndex;
+    }
+  }
+
+  private final List<Entry> entries = new ArrayList<>();
+
+  public void add(int rowIndex, String field, String message, String rawValue, Integer columnIndexNullable) {
+    entries.add(new Entry(rowIndex, field, message, rawValue, columnIndexNullable));
+  }
+
+  public boolean hasErrors() {
+    return !entries.isEmpty();
+  }
+
+  public List<Entry> entries() {
+    return List.copyOf(entries);
+  }
+  
+  public <T> List<T> map(Function<Entry, T> mapper) {
+    return entries.stream().map(mapper).toList();
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/excel/ExcelImportException.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/ExcelImportException.java
@@ -1,0 +1,12 @@
+package com.example.rentalSystem.global.excel;
+
+public class ExcelImportException extends RuntimeException {
+
+  public ExcelImportException(String message) {
+    super(message);
+  }
+
+  public ExcelImportException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/excel/HeaderMapper.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/HeaderMapper.java
@@ -1,0 +1,81 @@
+package com.example.rentalSystem.global.excel;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HeaderMapper {
+
+  public Map<String, Integer> map(Row headerRow, List<String> required, List<String> optional) {
+    if (headerRow == null) {
+      throw new ExcelImportException("헤더 행이 비어 있습니다.");
+    }
+
+    DataFormatter fmt = new DataFormatter(Locale.KOREA, true);
+    Map<String, Integer> map = new HashMap<>();
+    short last = headerRow.getLastCellNum();
+    for (int c = 0; c < last; c++) {
+      Cell cell = headerRow.getCell(c, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL);
+      if (cell == null) {
+        continue;
+      }
+      String h = fmt.formatCellValue(cell);
+      if (h == null) {
+        continue;
+      }
+      h = h.trim();
+      if (h.isEmpty()) {
+        continue;
+      }
+      map.put(h, c);
+    }
+    ensureRequired(map, required);
+    return map;
+  }
+
+  public void ensureRequired(Map<String, Integer> map, List<String> required) {
+    if (required == null || required.isEmpty()) {
+      return;
+    }
+    List<String> missing = required.stream()
+        .filter(h -> !map.containsKey(h))
+        .collect(Collectors.toList());
+    if (!missing.isEmpty()) {
+      throw new ExcelImportException("필수 헤더 누락: " + String.join(", ", missing));
+    }
+  }
+  
+  public int headerRowIndexDetect(Sheet sheet, int fallbackIndex) {
+    int first = sheet.getFirstRowNum();
+    int last = sheet.getLastRowNum();
+    for (int r = first; r <= last; r++) {
+      Row row = sheet.getRow(r);
+      if (row == null) {
+        continue;
+      }
+      if (!isBlankRow(row)) {
+        return r;
+      }
+    }
+    return fallbackIndex;
+  }
+
+  private boolean isBlankRow(Row row) {
+    DataFormatter fmt = new DataFormatter(Locale.KOREA, true);
+    for (Cell cell : row) {
+      String v = fmt.formatCellValue(cell);
+      if (v != null && !v.trim().isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/excel/RowReader.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/RowReader.java
@@ -1,0 +1,88 @@
+package com.example.rentalSystem.global.excel;
+
+import java.time.LocalTime;
+import java.util.Locale;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RowReader {
+
+  private final DataFormatter fmt = new DataFormatter(Locale.KOREA, true);
+  private final TimeNormalizer timeNormalizer;
+
+  public RowReader(TimeNormalizer timeNormalizer) {
+    this.timeNormalizer = timeNormalizer;
+  }
+
+  public String getString(Cell cell) {
+    if (cell == null) {
+      return null;
+    }
+    String s = fmt.formatCellValue(cell);
+    if (s == null) {
+      return null;
+    }
+    s = s.trim();
+    return s.isEmpty() ? null : s;
+  }
+
+  public Integer getInteger(Cell cell) {
+    if (cell == null) {
+      return null;
+    }
+    switch (cell.getCellType()) {
+      case NUMERIC -> {
+        return (int) Math.round(cell.getNumericCellValue());
+      }
+      case STRING -> {
+        String s = cell.getStringCellValue();
+        if (s == null) {
+          return null;
+        }
+        s = s.trim();
+        if (s.isEmpty()) {
+          return null;
+        }
+        try {
+          return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+          return null;
+        }
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+
+  public LocalTime getLocalTime(Cell cell) {
+    if (cell == null) {
+      return null;
+    }
+    switch (cell.getCellType()) {
+      case NUMERIC -> {
+        return timeNormalizer.toLocalTime(cell.getNumericCellValue());
+      }
+      case STRING -> {
+        String s = cell.getStringCellValue();
+        return timeNormalizer.toLocalTime(s);
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+
+  public boolean isBlankRow(Row row) {
+    for (Cell cell : row) {
+      String v = fmt.formatCellValue(cell);
+      if (v != null && !v.trim().isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/excel/TimeNormalizer.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/TimeNormalizer.java
@@ -1,0 +1,89 @@
+package com.example.rentalSystem.global.excel;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TimeNormalizer {
+
+  private static final DateTimeFormatter HHMM = DateTimeFormatter.ofPattern("HH:mm");
+  private static final DateTimeFormatter H_MM = DateTimeFormatter.ofPattern("H:mm", Locale.KOREA);
+  private static final DateTimeFormatter H_MMA = DateTimeFormatter.ofPattern("h:mma", Locale.KOREA);
+  private static final DateTimeFormatter HA = DateTimeFormatter.ofPattern("ha", Locale.KOREA);
+
+  public LocalTime toLocalTime(Object any) {
+    if (any == null) {
+      return null;
+    }
+
+    if (any instanceof LocalTime lt) {
+      return lt;
+    }
+
+    if (any instanceof Number num) {
+      double v = num.doubleValue();
+      double frac = v % 1.0;
+      if (frac < 0) {
+        frac += 1.0;
+      }
+      int totalSeconds = (int) Math.round(frac * 24 * 60 * 60);
+      int hour = (totalSeconds / 3600) % 24;
+      int minute = (totalSeconds % 3600) / 60;
+      return LocalTime.of(hour, minute);
+    }
+
+    String s = any.toString().trim();
+    if (s.isEmpty()) {
+      return null;
+    }
+
+    String up = s.replace("오전", "AM").replace("오후", "PM").toUpperCase(Locale.KOREA).replaceAll("\\s+", "");
+
+    try {
+      if (up.endsWith("AM") || up.endsWith("PM")) {
+        return LocalTime.parse(up, H_MMA);
+      }
+    } catch (Exception ignore) {
+    }
+    try {
+      if (up.endsWith("AM") || up.endsWith("PM")) {
+        return LocalTime.parse(up, HA);
+      }
+    } catch (Exception ignore) {
+    }
+
+    if (s.matches("^\\d{1,2}$")) {
+      s = s + ":00";
+    }
+    if (s.matches("^\\d{1,2}:\\d$")) {
+      s = s + "0";
+    }
+    if (s.matches("^\\d:\\d{2}$")) {
+      s = "0" + s;
+    }
+
+    if (s.matches("^\\d{3,4}$")) {
+      int n = Integer.parseInt(s);
+      int hour = n / 100;
+      int minute = n % 100;
+      return LocalTime.of(hour, minute);
+    }
+
+    try {
+      return LocalTime.parse(s, H_MM);
+    } catch (Exception ignore) {
+    }
+    try {
+      return LocalTime.parse(s, HHMM);
+    } catch (Exception ignore) {
+    }
+
+    throw new ExcelImportException("시간 포맷을 해석할 수 없습니다: " + any);
+  }
+
+  public String formatHHmm(LocalTime time) {
+    return time == null ? null : time.format(HHMM);
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/excel/WorkbookOpener.java
+++ b/src/main/java/com/example/rentalSystem/global/excel/WorkbookOpener.java
@@ -1,0 +1,39 @@
+package com.example.rentalSystem.global.excel;
+
+import java.io.InputStream;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkbookOpener {
+
+  public Workbook open(InputStream in) {
+    try {
+      return WorkbookFactory.create(in);
+    } catch (Exception e) {
+      throw new ExcelImportException("엑셀 파일을 열 수 없습니다.", e);
+    }
+  }
+
+  public Sheet firstNonEmptySheet(Workbook wb) {
+    for (int i = 0; i < wb.getNumberOfSheets(); i++) {
+      Sheet s = wb.getSheetAt(i);
+      if (s != null && s.getLastRowNum() >= s.getFirstRowNum()) {
+        return s;
+      }
+    }
+    throw new ExcelImportException("유효한 시트를 찾지 못했습니다.");
+  }
+
+  public Sheet getSheetByNameOrFirst(Workbook wb, String preferredName) {
+    if (preferredName != null) {
+      Sheet byName = wb.getSheet(preferredName);
+      if (byName != null) {
+        return byName;
+      }
+    }
+    return firstNonEmptySheet(wb);
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ExcelImporter.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ExcelImporter.java
@@ -1,0 +1,11 @@
+package com.example.rentalSystem.global.importer;
+
+import com.example.rentalSystem.global.excel.ErrorCollector;
+import org.apache.poi.ss.usermodel.Workbook;
+
+public interface ExcelImporter<T> {
+
+  boolean supports(Workbook wb);
+  
+  ImportParseResult<T> parse(Workbook wb, ImportContext ctx, ErrorCollector errors);
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportContext.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportContext.java
@@ -1,0 +1,46 @@
+package com.example.rentalSystem.global.importer;
+
+import java.time.LocalDate;
+
+public class ImportContext {
+
+  private final LocalDate validStartDate;
+  private final LocalDate validEndDate;
+
+  private ImportContext(Builder b) {
+    this.validStartDate = b.validStartDate;
+    this.validEndDate = b.validEndDate;
+  }
+
+  public LocalDate getValidStartDate() {
+    return validStartDate;
+  }
+
+  public LocalDate getValidEndDate() {
+    return validEndDate;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private LocalDate validStartDate;
+    private LocalDate validEndDate;
+
+    public Builder validStartDate(LocalDate d) {
+      this.validStartDate = d;
+      return this;
+    }
+
+    public Builder validEndDate(LocalDate d) {
+      this.validEndDate = d;
+      return this;
+    }
+
+    public ImportContext build() {
+      return new ImportContext(this);
+    }
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportError.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportError.java
@@ -1,0 +1,28 @@
+package com.example.rentalSystem.global.importer;
+
+public class ImportError {
+
+  private final int rowIndex;
+  private final String field;
+  private final String message;
+
+
+  public ImportError(int rowIndex, String field, String message, String rawValue, Integer columnIndex) {
+    this.rowIndex = rowIndex;
+    this.field = field;
+    this.message = message;
+  }
+
+  public int getRowIndex() {
+    return rowIndex;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportManager.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportManager.java
@@ -1,0 +1,68 @@
+package com.example.rentalSystem.global.importer;
+
+import com.example.rentalSystem.global.excel.ErrorCollector;
+import com.example.rentalSystem.global.excel.ExcelImportException;
+import com.example.rentalSystem.global.excel.WorkbookOpener;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class ImportManager {
+
+  private final WorkbookOpener opener;
+  private final List<ExcelImporter<?>> importers;
+
+  public ImportManager(WorkbookOpener opener, List<ExcelImporter<?>> importers) {
+    this.opener = opener;
+    this.importers = importers;
+    System.out.println("[ImportManager] loaded importers: " +
+        importers.stream().map(i -> i.getClass().getName()).toList());
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T> ImportParseResult<T> importExcel(MultipartFile file, ImportType type, ImportContext ctx) {
+    try (InputStream in = file.getInputStream(); Workbook wb = opener.open(in)) {
+      List<ExcelImporter<?>> candidates = importers.stream()
+          .filter(imp -> safeSupports(imp, wb))
+          .collect(Collectors.toList());
+
+      if (candidates.isEmpty()) {
+        throw new ExcelImportException("지원되는 임포터가 없습니다. 파일 포맷을 확인하세요.");
+      }
+      if (candidates.size() > 1 && type == ImportType.AUTO) {
+        throw new ExcelImportException("여러 임포터가 동시에 매칭되었습니다. 파일 포맷을 명확히 하세요.");
+      }
+
+      ExcelImporter<?> importer = chooseByTypeOrSingle(candidates, type);
+
+      ErrorCollector ec = new ErrorCollector();
+      ImportParseResult<?> result = importer.parse(wb, ctx, ec);
+
+      return (ImportParseResult<T>) result;
+
+    } catch (ExcelImportException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new ExcelImportException("임포트 처리 중 오류가 발생했습니다.", e);
+    }
+  }
+
+  private boolean safeSupports(ExcelImporter<?> imp, Workbook wb) {
+    try {
+      return imp.supports(wb);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  private ExcelImporter<?> chooseByTypeOrSingle(List<ExcelImporter<?>> candidates, ImportType type) {
+    if (type == ImportType.AUTO || candidates.size() == 1) {
+      return candidates.get(0);
+    }
+    return candidates.get(0);
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportParseResult.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportParseResult.java
@@ -1,0 +1,33 @@
+package com.example.rentalSystem.global.importer;
+
+import java.util.List;
+import java.util.Map;
+
+public class ImportParseResult<T> {
+
+  private final List<T> items;
+  private final List<ImportError> errors;
+  private final int totalRows;
+
+  public ImportParseResult(List<T> items, List<ImportError> errors, int totalRows, Map<String, Object> meta) {
+    this.items = items;
+    this.errors = errors;
+    this.totalRows = totalRows;
+  }
+
+  public List<T> getItems() {
+    return items;
+  }
+
+  public List<ImportError> getErrors() {
+    return errors;
+  }
+
+  public int getTotalRows() {
+    return totalRows;
+  }
+
+  public static <T> ImportParseResult<T> of(List<T> items, List<ImportError> errors, int totalRows) {
+    return new ImportParseResult<>(items, errors, totalRows, Map.of());
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportPolicy.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportPolicy.java
@@ -1,0 +1,24 @@
+package com.example.rentalSystem.global.importer;
+
+public class ImportPolicy {
+
+  private final boolean overwriteWithNewData;
+  private final boolean fillNullsFromNewData;
+
+  public ImportPolicy() {
+    this(true, true);
+  }
+
+  public ImportPolicy(boolean overwriteWithNewData, boolean fillNullsFromNewData) {
+    this.overwriteWithNewData = overwriteWithNewData;
+    this.fillNullsFromNewData = fillNullsFromNewData;
+  }
+
+  public boolean isOverwriteWithNewData() {
+    return overwriteWithNewData;
+  }
+
+  public boolean isFillNullsFromNewData() {
+    return fillNullsFromNewData;
+  }
+}

--- a/src/main/java/com/example/rentalSystem/global/importer/ImportType.java
+++ b/src/main/java/com/example/rentalSystem/global/importer/ImportType.java
@@ -1,0 +1,5 @@
+package com.example.rentalSystem.global.importer;
+
+public enum ImportType {
+  FACILITY, TIMETABLE, AUTO
+}


### PR DESCRIPTION
- global.excel 패키지 추가 (엑셀 파싱/처리 유틸)
- global.importer 패키지 추가 (공용 임포트 컨텍스트/결과/에러 구조)

# 요약
엑셀 기반 데이터 임포트를 공통화하기 위해 `global.excel`, `global.importer` 패키지를 추가.  
엑셀 파싱/처리 로직을 모듈화하고, 임포트 시 공용으로 사용하는 컨텍스트/결과/에러 구조를 도입.

# 작업 내용
- `global.excel` 패키지 생성
  - 엑셀 파싱/처리 유틸 클래스 추가
- `global.importer` 패키지 생성
  - `ImportContext`, `ImportParseResult`, `ImportError` 등 공용 구조 정의
- 기존 `schedule` 내 임포트 관련 클래스 일부를 global 레벨로 이동 및 정리

# 기타 (논의하고 싶은 부분)
- 필수값 검증을 어디까지 global 레벨에서 처리할지 논의 필요
- 관리자의 실수로 엑셀(xls, xlsx) 파일에 null 값이 들어가서 스케줄 등록에 실패하면, 상세 에러메시지를 띄울지 고민 필요

# 타 직군 전달 사항
- 프론트: 응답 포맷(`RowError`)이 확장되어 필드별 누락 사유를 확인할 수 있습니다.
- 기획/운영: 엑셀 업로드 시 어떤 값이 누락되었는지 명확하게 에러가 반환됩니다.  