### PR TITLE
feat: 시설 전체 삭제 시 FK/이미지 정리 포함되도록 수정

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
@@ -259,22 +259,15 @@ public class FacilityService {
     }
   }
 
+  // 단건삭제 재활용, 퍼포먼스 고려해서 리펙토링 필요
   @Transactional
   public void deleteAllFacilities() {
-    // 1) 모든 시설 로드
+    // 모든 시설 조회
     List<Facility> all = facilityJpaRepository.findAll();
 
-    // 2) 모든 이미지 키 수집
-    List<String> allKeys = all.stream()
-        .flatMap(f -> (f.getImages() == null ? List.<String>of().stream() : f.getImages().stream()))
-        .toList();
-
-    // 3) DB 일괄 삭제
-    facilityJpaRepository.deleteAllInBatch(); // FK 제약 고려해서 batch delete
-
-    // 4) S3 일괄 삭제
-    for (String key : allKeys) {
-      s3Service.deleteObjectIfExists(key);
+    // 기존 단건 삭제 로직 재사용 (자식/FK/S3 정리 포함)
+    for (Facility f : all) {
+      delete(f.getId());
     }
   }
 


### PR DESCRIPTION
## 변경 사항
- 기존 deleteAllInBatch() 사용 방식에서 → 단건 삭제 로직 재사용으로 변경
- 시설 전체 삭제 시:
  - 자식 엔티티(FK) 정리
  - DB 삭제
  - S3 이미지 삭제
  모두 정상 수행되도록 수정

## 배경
- 기존 방식(deleteAllInBatch())은 schedule 등 FK 제약으로 인해 삭제 실패 발생
- 단건 삭제 로직은 FK/이미지 처리 로직이 포함되어 있어 안정적으로 삭제 가능

## 참고
- 추후 데이터가 많아져 퍼포먼스 이슈가 생기면 자식 일괄 삭제 + 부모 일괄 삭제 방식(퍼포먼스 고려)으로 개선 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 전체 시설 삭제 동작이 단건 삭제와 동일한 절차를 따르도록 정비되었습니다.
  - 사용자 관점에서 삭제 처리의 일관성과 안정성이 향상되었으며, 관련 리소스 정리(예: 첨부 파일 등)도 동일 기준으로 수행됩니다.
  - 트랜잭션 내 처리로 예외 발생 시 롤백 일관성이 강화되었습니다.
  - 대량 삭제 시 처리 시간이 변경될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->