### PR TITLE
시설 중복 등록 시 전용 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/example/rentalSystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/rentalSystem/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.rentalSystem.global.exception;
 
+import com.example.rentalSystem.domain.facility.exception.FacilityConflictException;
 import com.example.rentalSystem.global.exception.custom.CustomException;
 import com.example.rentalSystem.global.response.ApiResponse;
 import com.example.rentalSystem.global.response.type.ErrorType;
@@ -41,5 +42,15 @@ public class GlobalExceptionHandler {
         .findFirst()
         .orElse("잘못된 요청입니다.");
     return ApiResponse.error(ErrorType.INVALID_REQUEST, errorMessage);
+  }
+
+  @ExceptionHandler(FacilityConflictException.class)
+  public ApiResponse<?> handleFacilityConflict(FacilityConflictException e) {
+    log.warn("FacilityConflictException", e);
+    return ApiResponse.error(
+        ErrorType.DUPLICATE_RESOURCE,
+        ErrorType.DUPLICATE_RESOURCE.getMessage(),
+        e.getConflictFacility()   // 기존 시설 상세 스냅샷
+    );
   }
 }


### PR DESCRIPTION
## 작업 내용
- GlobalExceptionHandler에 @ExceptionHandler(FacilityConflictException.class) 추가
- 중복된 시설 등록 시 409 상태 코드와 함께 기존 시설 상세 정보 반환
- ApiResponse.error(ErrorType.DUPLICATE_RESOURCE, ...) 형태로 응답 통일

## 변경 이유
- 기존에는 중복 시설 발생 시 예외가 적절히 처리되지 않아 응답 데이터가 부족했음
- 프론트엔드에서 사용자에게 어떤 시설이 이미 등록되어 있는지 보여주기 위함

## 주요 응답 예시
```json
{
  "httpStatusCode": 409,
  "message": "이미 등록된 시설(시설유형 + 시설번호) 입니다.",
  "data": {
    "id": 2206,
    "facilityType": "MAIN_BUILDING",
    "facilityNumber": "S1350",
    ...
  },
  "resultType": "FAIL"
}