### PR TITLE
이미지 삭제 하드 딜리트 기본화(프론트 옵션 없이 동작)

### DIFF
--- a/src/main/java/com/example/rentalSystem/domain/facility/dto/request/UpdateFacilityRequestDto.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/dto/request/UpdateFacilityRequestDto.java
@@ -18,9 +18,7 @@ public record UpdateFacilityRequestDto(
     List<String> allowedBoundary,
     List<String> addFileNames,
     List<String> removeKeys,
-    List<String> newOrder,
-    Boolean hardDelete
-
+    List<String> newOrder
 ) {
 
 }

--- a/src/main/java/com/example/rentalSystem/domain/facility/exception/FacilityConflictException.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/exception/FacilityConflictException.java
@@ -1,4 +1,3 @@
-// src/main/java/com/example/rentalSystem/domain/facility/exception/FacilityConflictException.java
 package com.example.rentalSystem.domain.facility.exception;
 
 import com.example.rentalSystem.domain.facility.dto.response.FacilityDetailResponse;

--- a/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
+++ b/src/main/java/com/example/rentalSystem/domain/facility/service/FacilityService.java
@@ -81,7 +81,7 @@ public class FacilityService {
           dto.startTime(), dto.endTime(), dto.capacity(), dto.isAvailable(),
           dto.allowedBoundary(), dto.fileNames(),
           existing.getImages() == null ? List.of() : new ArrayList<>(existing.getImages()),
-          null, false
+          null
       );
       return update(updateDto, existing.getId());
     }
@@ -160,13 +160,14 @@ public class FacilityService {
     );
 
     // 3) 이미지 처리: remove → add → 정렬
+    // FacilityService.update(...)
     List<String> images = new ArrayList<>(origin.getImages() == null ? List.of() : origin.getImages());
 
-    // (1) 삭제
+// (1) 삭제: 무조건 S3에서도 제거
     if (dto.removeKeys() != null && !dto.removeKeys().isEmpty()) {
       for (String rk : dto.removeKeys()) {
-        if (images.remove(rk) && Boolean.TRUE.equals(dto.hardDelete())) {
-          s3Service.deleteObjectIfExists(rk); // 없으면 조용히 무시
+        if (images.remove(rk)) {
+          s3Service.deleteObjectIfExists(rk); // <- 항상 하드 삭제
         }
       }
     }


### PR DESCRIPTION

	•	시설 수정 API에서 이미지 삭제 시 S3까지 항상 삭제되도록 기본화
	•	DTO에서 hardDelete 제거하여 프론트 단 로직 단순화
	•	기존 단건/전체 삭제 API는 변경 없음 (이미 S3 삭제 포함)